### PR TITLE
Add Host a Node page and community growth playbook

### DIFF
--- a/docs/COMMUNITY-GROWTH-PLAYBOOK.md
+++ b/docs/COMMUNITY-GROWTH-PLAYBOOK.md
@@ -1,0 +1,101 @@
+# Community Growth Playbook
+
+A working strategy doc for KC Mesh. Started after the Discord crossed **200 members** and a Cascadia Mesh community member pointed us at [cascadiamesh.org](https://cascadiamesh.org/) as a model for growth — especially for getting businesses and infrastructure hosts to participate.
+
+This isn't a public marketing page. It's a private working document — the thing I (Jeremy) come back to when I'm trying to figure out what to do next, what's already been tried, and what we explicitly decided to wait on.
+
+## Why this exists
+
+Up to ~200 Discord members, growth has been organic. New folks find the site, install a node, say hello on the mesh, lurk in the Discord. That's a great on-ramp for hobbyists who already know what Meshtastic is.
+
+It's a lousy on-ramp for the people who unlock the next jump in coverage:
+
+- A warehouse owner with a flat 30-foot roof and an unused outlet
+- A church with a steeple and a tech-curious deacon
+- A ham radio operator with a 60-foot tower and weekly nets
+- A school IT director who runs the campus repeater
+- A billboard owner with sites along I-435
+
+These people don't read the Meshtastic subreddit. They don't know what LoRa is. They need a story, a clear "what do you need from me," and a reason to say yes that isn't "join Discord."
+
+That's the gap this playbook is trying to close.
+
+## The Cascadia playbook — what works
+
+Synthesized from observing [cascadiamesh.org](https://cascadiamesh.org/), [meshamerica.com](https://meshamerica.com/), and the I-5 Project they're running across the Pacific Northwest:
+
+1. **A flagship corridor initiative gives them a story-shaped pitch.** Cascadia's I-5 Project isn't "host a node." It's "help us close the gap between Olympia and Vancouver, WA along I-5." A specific corridor, a specific gap, a specific reason to call right now. That's much easier to say yes to than abstract infrastructure participation.
+
+2. **Concrete site requirements let hosts self-qualify in 30 seconds.** They tell you up front: high elevation, clear 910 MHz LoRa line of sight along the corridor, willingness to support a small solar-powered repeater. A building owner can scan that and immediately know whether their roof is in scope.
+
+3. **An anchor success story makes it real.** Their first deployment is a billboard owner near Mayfield, WA who donated tower space. Once you have one, prospective hosts stop asking "is this serious?" and start asking "what does our site look like for this?"
+
+4. **A sister 501(c)(3) (Mesh America) owns the long-term infrastructure work.** It accepts tax-deductible donations, is raising $35K specifically for tower colocation insurance, and provides the legal/financial scaffolding that lets serious businesses sign on without a million questions. The hobbyist Discord stays a hobbyist Discord; the nonprofit handles the boring grown-up stuff.
+
+5. **A dedicated host email — not just "join Discord."** Cascadia uses [email protected] for I-5 conversations. Hosts get a real channel that doesn't disappear into a fast-moving chat.
+
+6. **Multi-audience welcome language and concrete use-case storytelling.** They name "makers, coders, neighbors and organizations" and list real reasons people care: emergency prep, festival comms, sensor networks, off-grid backup for kids. Anyone reading can find themselves in it.
+
+7. **Regional sub-meshes under one umbrella.** Salish Mesh (and others) operate as sub-regions of Cascadia. A federation model that lets adjacent metros plug in without diluting either brand.
+
+## What KC is adopting now
+
+These are the changes shipping in the same PR as this doc:
+
+### KC Backbone Initiative — our version of "the I-5 Project"
+
+The four-router cardinal-coverage plan (East / West / North / South) that already exists in [`CLAUDE.md`](../CLAUDE.md) is being elevated from "Jeremy's planning doc" to a public-facing flagship project name. It gives us a story to tell hosts and a specific ask: help close the West-side gap (current critical priority).
+
+### `/host-a-node` page
+
+A dedicated recruitment funnel built on Cascadia's template:
+
+- A specific "we need help here right now" hook (the West-side gap)
+- Concrete site requirements anyone can self-qualify against
+- Audience cards naming every kind of host we want to reach
+- A "what KC Mesh provides in return" section so we don't just sound like we're asking for free real estate
+- Anchor proof point: my own router as the first success story
+- A direct host email + a softer "just lurk in Discord" CTA for people who aren't ready
+
+### Hero stat update
+
+Surfacing the 200-member Discord milestone alongside the existing node counts. Same line, just adds "200+ in Discord." Cheapest possible social proof bump.
+
+### Homepage cross-promotion
+
+A new section between Resources and the Final CTA that links to `/host-a-node`. Doesn't disrupt the existing flow, just gives the new page a homepage entry point.
+
+## What KC is adopting later (in priority order)
+
+These are the next moves once the current PR has been in production for a while and we've watched what happens.
+
+1. **Anchor case study with photos.** Once we land a second hosted site — a real third-party host, not just my own router — write it up properly. Photos of the install, what they get out of it, what we got out of it. Replace the placeholder success story on the Host a Node page with the real one. This is the single highest-leverage upgrade to the page.
+
+2. **Recurring meetups / build nights.** A standing monthly thing (probably a maker space or someone's garage) where people can show up with hardware questions, get help flashing firmware, and meet other KC folks. Hard to overstate how much faster trust builds when people have met each other in person. Cascadia has regional in-person events; we should too.
+
+3. **Cross-mesh cross-promotion.** A Cascadia member just gave us a referral. Return the favor — link out to them on the Host a Node page or the Resources section, and proactively connect with other regional meshes (Mesh America has a directory). The mesh community is small; this is positive-sum.
+
+4. **A "Regions" model if adjacent metros want to federate.** Not until someone in Lawrence, Topeka, or St. Joseph says "we want to be part of this." Don't manufacture demand. But have the answer ready: "yes, you can be Lawrence Mesh under the KC Mesh umbrella, here's what that means."
+
+5. **501(c)(3) formation.** Trigger conditions: 3+ hosted infrastructure sites live, at least one of which is a real business partnership (not a personal favor), AND a specific reason the lack of a nonprofit is blocking us (tower colocation insurance, a donor who needs tax-deductibility, etc.). Don't form a nonprofit just to have one — it's real overhead. Reference Mesh America's structure when the time comes. Until then, "we're a hobbyist project" is an honest, freeing answer.
+
+## Growth tactics inventory
+
+A running list of moves that work in mesh / civic / volunteer communities. Not all of them are for now — this is the bench.
+
+- **Audience-specific landing paths.** Different hooks for ham operators vs. business hosts vs. HOA homeowners vs. emergency-prep folks. We have the Host a Node page now; we should eventually build dedicated deployment guides per `CLAUDE.md`'s planned structure.
+- **Anchor case studies.** Real installs with photos, costs, and outcomes. Each one removes a category of objection.
+- **Concrete site requirements.** Self-qualification checklist so we're not fielding a hundred "would my house work" questions.
+- **Multi-tier participation paths.** Host a node, run a client, hang out in Discord, show up to a meetup, write documentation, donate hardware. Lots of doors in, low pressure to escalate.
+- **Recurring in-person events.** Meetups, build nights, field days. Trust + skills compound fast in person.
+- **Cross-mesh cross-promotion.** Link out to other regional meshes; ask them to link to us. Show up in their Discords occasionally.
+- **Direct contact channels by audience.** A host email for serious infrastructure conversations. Discord for everyone else.
+- **Visible social proof.** Node counts, Discord size, miles of coverage, story count. Numbers go up → people trust the project is real.
+- **Honest scope.** Anti-perfectionism, anti-corporate. Per `CLAUDE.md` and `AGENTS.md` — hobbyist tone, weekend project, $25–$200 hardware. Don't oversell.
+
+## Sources
+
+- [Cascadia Mesh — cascadiamesh.org](https://cascadiamesh.org/)
+- [Mesh America — meshamerica.com](https://meshamerica.com/)
+- [The I-5 Project page on Mesh America](https://meshamerica.com/the-i-5-project/)
+- KC Mesh internal: [`CLAUDE.md`](../CLAUDE.md), [`AGENTS.md`](../AGENTS.md), [`README.md`](../README.md)

--- a/docs/COMMUNITY-GROWTH-PLAYBOOK.md
+++ b/docs/COMMUNITY-GROWTH-PLAYBOOK.md
@@ -44,13 +44,15 @@ These are the changes shipping in the same PR as this doc:
 
 ### KC Backbone Initiative — our version of "the I-5 Project"
 
-The four-router cardinal-coverage plan (East / West / North / South) that already exists in [`CLAUDE.md`](../CLAUDE.md) is being elevated from "Jeremy's planning doc" to a public-facing flagship project name. It gives us a story to tell hosts and a specific ask: help close the West-side gap (current critical priority).
+The hosted-infrastructure rollout from [`CLAUDE.md`](../CLAUDE.md) is being elevated from "Jeremy's planning doc" to a public-facing flagship project name — and re-scoped to match what's actually on the map. The I-35 spine (downtown through Overland Park and the southern suburbs) is strong. The current gaps are two parallel ones: **(1)** the metro's east and west edges — Bonner Springs, Independence, Blue Springs — and **(2)** the I-70 corridor in both directions, where existing outlier nodes in Manhattan, KS and Columbia, MO can't reliably reach the KC mesh because the intermediate hop chain doesn't exist yet. The Backbone Initiative is the named ask for both.
+
+*(Note: `CLAUDE.md` still describes the older four-router cardinal framing — worth updating that doc to match this scoping when convenient. They're now out of sync.)*
 
 ### `/host-a-node` page
 
 A dedicated recruitment funnel built on Cascadia's template:
 
-- A specific "we need help here right now" hook (the West-side gap)
+- Specific "we need help here right now" hooks: metro-edge cities (Bonner Springs, Independence, Blue Springs) and the I-70 hop chain out to existing outliers in Manhattan and Columbia
 - Concrete site requirements anyone can self-qualify against
 - Audience cards naming every kind of host we want to reach
 - A "what KC Mesh provides in return" section so we don't just sound like we're asking for free real estate

--- a/docs/HOST-A-NODE-DRAFT.md
+++ b/docs/HOST-A-NODE-DRAFT.md
@@ -14,11 +14,15 @@ Hosted infrastructure is the single biggest thing standing between KC Mesh today
 
 ## Why hosted infrastructure matters
 
-KC Mesh has 60+ active nodes today. Most of them are client nodes — handhelds, indoor home setups, T-Decks in backpacks. They're great for local conversations, but client-only density doesn't carry a message from Liberty to Olathe.
+KC Mesh has 60+ active nodes today, and we've built a strong spine running up and down the I-35 corridor — messages move cleanly between downtown, Westport, Overland Park, and the southern suburbs. That spine is real progress, and it's the foundation everything else builds on.
 
-What does carry that message is a small number of router nodes mounted high, with clear sky, running 24/7. The plan is four of them: East, West, North, and South. Together they form what we're calling the **KC Backbone Initiative** — the spine that turns a bunch of friendly hobbyist nodes into a metro-wide network.
+What we don't yet have is a mesh that reaches the metro's east and west edges, much less the cities just outside it. Most of our 60+ nodes are client nodes — handhelds, indoor home setups, T-Decks in backpacks — and client-only density doesn't carry a message from Westport to Blue Springs.
 
-> **The West side is the current critical gap.** If you own or manage a building, billboard, tower, or rooftop anywhere from Lenexa west to the state line, you might be exactly the host we've been looking for.
+The fix is a small number of router nodes mounted high, with clear sky, running 24/7. We're calling the rollout the **KC Backbone Initiative**, and it has two parallel asks:
+
+> **1. Round out the metro.** Bonner Springs on the west side. Independence and Blue Springs to the east. These are the gaps where messages from downtown die before they reach you. If you own or manage a building, billboard, tower, or rooftop in or near those cities, you might be exactly the host we've been looking for.
+>
+> **2. Close the chain to the outliers.** There are already nodes on the map as far out as Manhattan, KS and Columbia, MO — but they can't reliably reach the KC mesh because the hop chain between them and downtown doesn't exist yet. Lawrence, Topeka, Lee's Summit, Warrensburg — every host along I-70 in either direction is a link that makes those far-out nodes part of the network.
 
 ---
 
@@ -45,7 +49,7 @@ We're talking about a $60–$200 device the size of a paperback, plus a small an
 If you see yourself in any of these, you're exactly who we're trying to reach.
 
 **Businesses with rooftops**
-Warehouses, retail strip centers, offices. If you have a flat roof and a 120V outlet on it, you have what we need. We're especially looking on the West side of the metro.
+Warehouses, retail strip centers, offices. If you have a flat roof and a 120V outlet on it, you have what we need. We're especially looking in Bonner Springs, Independence, and Blue Springs — plus any spot along I-70 (east or west) where a hop helps connect existing outlier nodes in Manhattan and Columbia back to the KC mesh.
 
 **Ham operators & repeater owners**
 You already have what we need — elevation, line of sight, and the inclination to mess with radios. A Meshtastic router at your repeater site is a $60 add to infrastructure you've already built.
@@ -85,7 +89,7 @@ Right now the proof-of-concept is my own router. It's a Heltec V3 in a weatherpr
 
 It's been online for months. It hands off traffic between client nodes that can't hear each other directly. It made the difference between "a few people messing around" and "a network."
 
-We need three more. East, West, North, South. That's the whole ask.
+We need more like it — out at the edges, and along I-70 in both directions to close the chain to the existing outliers. That's the whole ask.
 
 ---
 

--- a/docs/HOST-A-NODE-DRAFT.md
+++ b/docs/HOST-A-NODE-DRAFT.md
@@ -1,0 +1,99 @@
+# Host a Node — page draft
+
+> Draft of the `/host-a-node` page content, in plain markdown for feedback. The shipped page on the site has the same words wrapped in JSX, color, and audience cards — but the messaging is identical to what's below. Mark it up freely.
+
+---
+
+**KC Backbone Initiative**
+
+# Got a rooftop, a tower, or a high spot? We need you.
+
+Hosted infrastructure is the single biggest thing standing between KC Mesh today and KC Mesh covering the whole metro. If you have elevation and a willing outlet, we'd love to talk.
+
+---
+
+## Why hosted infrastructure matters
+
+KC Mesh has 60+ active nodes today. Most of them are client nodes — handhelds, indoor home setups, T-Decks in backpacks. They're great for local conversations, but client-only density doesn't carry a message from Liberty to Olathe.
+
+What does carry that message is a small number of router nodes mounted high, with clear sky, running 24/7. The plan is four of them: East, West, North, and South. Together they form what we're calling the **KC Backbone Initiative** — the spine that turns a bunch of friendly hobbyist nodes into a metro-wide network.
+
+> **The West side is the current critical gap.** If you own or manage a building, billboard, tower, or rooftop anywhere from Lenexa west to the state line, you might be exactly the host we've been looking for.
+
+---
+
+## What makes a great host site
+
+Honest list. If your site checks most of these, please get in touch — we can work around the rest.
+
+**Elevation — 15 feet and up**
+You don't need a 40-foot tower. A two-story roof works. A flagpole works. An attic with a clear southern exposure can work. The dogma about needing massive elevation is just dogma — get above the immediate clutter and you're already useful.
+
+**Sky that's not blocked by another building**
+LoRa at 915 MHz mostly cares about line of sight. If you can see other rooftops and the horizon in at least one direction, signals will travel. We'll help you pick the antenna and aim.
+
+**A 120V outlet — or room for a small solar panel**
+A wired node draws less power than a wifi router. Don't have an outlet on the roof? A 10W solar panel and a small battery run a node indefinitely. We've got documented setups for both.
+
+**Willingness to host modest hardware**
+We're talking about a $60–$200 device the size of a paperback, plus a small antenna. Not commercial telecom gear. Weekend-project scale. If something breaks, the worst case is somebody comes out and swaps the box.
+
+---
+
+## Who should consider hosting
+
+If you see yourself in any of these, you're exactly who we're trying to reach.
+
+**Businesses with rooftops**
+Warehouses, retail strip centers, offices. If you have a flat roof and a 120V outlet on it, you have what we need. We're especially looking on the West side of the metro.
+
+**Ham operators & repeater owners**
+You already have what we need — elevation, line of sight, and the inclination to mess with radios. A Meshtastic router at your repeater site is a $60 add to infrastructure you've already built.
+
+**Churches, schools, civic buildings**
+Steeples, water tanks, rooftop HVAC platforms — anywhere with elevation and a friendly facilities person. A great emergency-comms talking point for your community.
+
+**Billboard, water tower, cell tower owners**
+Cascadia's first big host was a billboard owner outside Mayfield, WA. The model works. If you own structures along I-29, I-35, I-70, or I-435, please get in touch.
+
+**Building managers & flagpole homeowners**
+Apartment buildings, condos, HOA-restricted neighborhoods with a flagpole or attic. Stealth deployments are absolutely a thing. 15 feet of elevation is genuinely useful.
+
+---
+
+## What KC Mesh provides in return
+
+This is a hobbyist project, not a vendor relationship. But here's what we bring to the table:
+
+**Equipment guidance — and sometimes the equipment itself**
+We'll pick hardware that fits your site, your power situation, and your budget. For priority backbone locations, we can usually find someone in the community willing to donate or split the cost of the device.
+
+**Hands-on deployment help**
+Someone from the community will come out, mount the antenna, configure the node, and confirm it's healthy on the mesh. You don't need to learn LoRa to host one.
+
+**Ongoing monitoring via Discord**
+If your node falls off the mesh, somebody in the Discord will notice — usually within an hour. We'll let you know and help you bring it back up.
+
+**Public credit on the coverage map**
+Your site shows up on [map.kansascitymesh.live](https://map.kansascitymesh.live) as a contributing backbone node. If you're a business, we'll happily call you out by name; if you'd rather be anonymous, we don't have to.
+
+---
+
+## What this looks like in practice
+
+Right now the proof-of-concept is my own router. It's a Heltec V3 in a weatherproof box, mounted about 25 feet up, drawing power from a regular outdoor outlet. Total hardware cost was under $100. Total install time was an afternoon.
+
+It's been online for months. It hands off traffic between client nodes that can't hear each other directly. It made the difference between "a few people messing around" and "a network."
+
+We need three more. East, West, North, South. That's the whole ask.
+
+---
+
+## Get in touch
+
+If you've got a site that sounds like it might fit — or you just want to talk it through to find out — please reach out. The fastest path is email, but Discord works too.
+
+- **Email about a host site:** [hello@orangefla.me](mailto:hello@orangefla.me?subject=KC%20Backbone%20Initiative%20%E2%80%94%20potential%20host%20site)
+- **Or come say hi in Discord:** [discord.gg/yr2QTFSvzN](https://discord.gg/yr2QTFSvzN)
+
+Not sure yet? No problem. The Discord is open — lurk for a while, see what people are doing, and circle back whenever it makes sense.

--- a/host-a-node.html
+++ b/host-a-node.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Host a Node — Kansas City Meshtastic Network</title>
+    <meta
+      name="description"
+      content="Got a rooftop, a tower, or a high spot in the KC metro? Help build the KC Backbone Initiative — the four-router spine that turns a friendly hobbyist mesh into metro-wide coverage."
+    />
+    <link rel="icon" type="image/png" href="/favicon-v2.png" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-PJQ97M0QBT"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        window.dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', 'G-PJQ97M0QBT', { send_page_view: false });
+    </script>
+  </head>
+  <body class="bg-black text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kansascitymesh.live",
-  "version": "0.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kansascitymesh.live",
-      "version": "0.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "lucide-react": "^0.259.0",
         "react": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,23 @@
 import { useEffect, useMemo, useState } from 'react';
 import HomePage from './components/HomePage';
 import GetStartedPage from './components/GetStartedPage';
+import HostANodePage from './components/HostANodePage';
 import { trackPageView } from './utils/analytics';
 
-type Page = 'home' | 'get-started';
+type Page = 'home' | 'get-started' | 'host';
 
 const getPageFromPath = (): Page => {
   if (typeof window === 'undefined') return 'home';
-  return window.location.pathname === '/getting-started' ? 'get-started' : 'home';
+  const path = window.location.pathname;
+  if (path === '/getting-started') return 'get-started';
+  if (path === '/host-a-node') return 'host';
+  return 'home';
 };
 
 const getPathForPage = (page: Page) => {
-  return page === 'home' ? '/' : '/getting-started';
+  if (page === 'get-started') return '/getting-started';
+  if (page === 'host') return '/host-a-node';
+  return '/';
 };
 
 export default function App() {
@@ -39,15 +45,16 @@ export default function App() {
     if (window.location.pathname !== nextPath) {
       window.history.pushState({}, '', nextPath);
     }
+    if (typeof window !== 'undefined') {
+      window.scrollTo({ top: 0, behavior: 'auto' });
+    }
   };
 
   return (
     <div className="min-h-screen bg-black">
-      {currentPage === 'home' ? (
-        <HomePage onNavigate={navigate} />
-      ) : (
-        <GetStartedPage onNavigate={navigate} />
-      )}
+      {currentPage === 'home' && <HomePage onNavigate={navigate} />}
+      {currentPage === 'get-started' && <GetStartedPage onNavigate={navigate} />}
+      {currentPage === 'host' && <HostANodePage onNavigate={navigate} />}
     </div>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,7 +4,7 @@ import { trackEvent } from '../utils/analytics';
 import { version } from '../../package.json';
 
 interface FooterProps {
-  onNavigate: (target: 'home' | 'get-started') => void;
+  onNavigate: (target: 'home' | 'get-started' | 'host') => void;
 }
 
 export default function Footer({ onNavigate }: FooterProps) {
@@ -12,9 +12,9 @@ export default function Footer({ onNavigate }: FooterProps) {
     <footer className="px-4 py-12 bg-[var(--neutral-900)] border-t border-white/10">
       <div className="max-w-6xl mx-auto">
         <nav className="flex flex-wrap justify-center gap-8 mb-8">
-          <a 
-            href="https://map.kansascitymesh.live" 
-            target="_blank" 
+          <a
+            href="https://map.kansascitymesh.live"
+            target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-1 text-white/60 hover:text-white transition-colors text-sm"
           >
@@ -26,6 +26,12 @@ export default function Footer({ onNavigate }: FooterProps) {
             className="text-white/60 hover:text-white transition-colors text-sm"
           >
             Get Started
+          </button>
+          <button
+            onClick={() => onNavigate('host')}
+            className="text-white/60 hover:text-white transition-colors text-sm"
+          >
+            Host a Node
           </button>
           <a
             href={DISCORD_INVITE}

--- a/src/components/GetStartedPage.tsx
+++ b/src/components/GetStartedPage.tsx
@@ -5,7 +5,7 @@ import Footer from './Footer';
 import { DISCORD_INVITE } from '../constants/discord';
 
 interface GetStartedPageProps {
-  onNavigate: (target: 'home' | 'get-started') => void;
+  onNavigate: (target: 'home' | 'get-started' | 'host') => void;
 }
 
 export default function GetStartedPage({ onNavigate }: GetStartedPageProps) {

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -53,7 +53,7 @@ export default function HeroSection() {
                 <Radio className="w-5 h-5 text-[var(--success-500)]" />
               </div>
               <div>
-                <h3 className="text-lg mb-1 text-white">60+ active nodes. 130+ total nodes.</h3>
+                <h3 className="text-lg mb-1 text-white">60+ active nodes. 130+ total nodes. 200+ in Discord.</h3>
                 <p className="text-white/60 leading-relaxed">
                   Power up a Meshtastic node and say hello. We're always welcoming newcomers.
                 </p>

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,12 +1,13 @@
 import HeroSection from './HeroSection';
 import HardwareSection from './HardwareSection';
 import ResourcesSection from './ResourcesSection';
+import HostInfrastructureCTA from './HostInfrastructureCTA';
 import FinalCTASection from './FinalCTASection';
 import Footer from './Footer';
 import Nav from './Nav';
 
 interface HomePageProps {
-  onNavigate: (target: 'home' | 'get-started') => void;
+  onNavigate: (target: 'home' | 'get-started' | 'host') => void;
 }
 
 export default function HomePage({ onNavigate }: HomePageProps) {
@@ -16,6 +17,7 @@ export default function HomePage({ onNavigate }: HomePageProps) {
       <HeroSection />
       <HardwareSection />
       <ResourcesSection />
+      <HostInfrastructureCTA onNavigate={onNavigate} />
       <FinalCTASection />
       <Footer onNavigate={onNavigate} />
     </div>

--- a/src/components/HostANodePage.tsx
+++ b/src/components/HostANodePage.tsx
@@ -1,0 +1,286 @@
+import { ChevronLeft, Info, MapPin, Radio, Building2, Signal, Church, Megaphone, Home } from 'lucide-react';
+import DiscordButton from './DiscordButton';
+import Nav from './Nav';
+import Footer from './Footer';
+import PulsingDot from './PulsingDot';
+import { DISCORD_INVITE } from '../constants/discord';
+import { trackEvent } from '../utils/analytics';
+
+interface HostANodePageProps {
+  onNavigate: (target: 'home' | 'get-started' | 'host') => void;
+}
+
+const HOST_EMAIL = 'hello@orangefla.me';
+
+const hostTypes = [
+  {
+    name: 'Businesses with rooftops',
+    description: "Warehouses, retail strip centers, offices. If you have a flat roof and a 120V outlet on it, you have what we need. We're especially looking on the West side of the metro.",
+    icon: <Building2 className="w-6 h-6 text-white" />,
+    color: 'from-[var(--primary-600)] to-[var(--primary-800)]',
+  },
+  {
+    name: 'Ham operators & repeater owners',
+    description: "You already have what we need — elevation, line of sight, and the inclination to mess with radios. A Meshtastic router at your repeater site is a $60 add to infrastructure you've already built.",
+    icon: <Signal className="w-6 h-6 text-white" />,
+    color: 'from-[var(--success-600)] to-[var(--success-700)]',
+  },
+  {
+    name: 'Churches, schools, civic buildings',
+    description: "Steeples, water tanks, rooftop HVAC platforms — anywhere with elevation and a friendly facilities person. A great emergency-comms talking point for your community.",
+    icon: <Church className="w-6 h-6 text-white" />,
+    color: 'from-[var(--secondary-600)] to-[var(--secondary-700)]',
+  },
+  {
+    name: 'Billboard, water tower, cell tower owners',
+    description: "Cascadia's first big host was a billboard owner outside Mayfield, WA. The model works. If you own structures along I-29, I-35, I-70, or I-435, please get in touch.",
+    icon: <Megaphone className="w-6 h-6 text-white" />,
+    color: 'from-[var(--warning-600)] to-[var(--warning-700)]',
+  },
+  {
+    name: 'Building managers & flagpole homeowners',
+    description: "Apartment buildings, condos, HOA-restricted neighborhoods with a flagpole or attic. Stealth deployments are absolutely a thing. 15 feet of elevation is genuinely useful.",
+    icon: <Home className="w-6 h-6 text-white" />,
+    color: 'from-[var(--info-600)] to-[var(--info-700)]',
+  },
+];
+
+export default function HostANodePage({ onNavigate }: HostANodePageProps) {
+  return (
+    <div className="min-h-screen bg-[var(--neutral-950)]">
+      <Nav onNavigate={onNavigate} currentPage="host" />
+
+      {/* Hero */}
+      <div
+        className="px-4 py-20 mt-16 border-b border-white/10 relative overflow-hidden"
+        style={{
+          backgroundImage:
+            'linear-gradient(180deg, var(--primary-800) 0%, var(--neutral-950) 90%, #000 100%)',
+        }}
+      >
+        <div className="absolute inset-0 -z-10">
+          <div
+            className="absolute top-0 left-1/4 w-96 h-96 rounded-full blur-3xl"
+            style={{ backgroundColor: 'var(--success-500)', opacity: 0.25 }}
+          ></div>
+          <div
+            className="absolute top-1/4 right-1/4 w-96 h-96 rounded-full blur-3xl"
+            style={{ backgroundColor: 'var(--secondary-600)', opacity: 0.25 }}
+          ></div>
+        </div>
+
+        <div className="max-w-3xl mx-auto">
+          <button
+            onClick={() => onNavigate('home')}
+            className="flex items-center gap-2 text-white/60 hover:text-white transition-colors mb-8"
+          >
+            <ChevronLeft className="w-4 h-4" />
+            Back to home
+          </button>
+
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 bg-white/10 backdrop-blur-sm rounded-full border border-white/20 mb-6">
+            <PulsingDot />
+            <span className="text-sm text-white/80 font-medium">KC Backbone Initiative</span>
+          </div>
+
+          <h1 className="text-5xl md:text-6xl mb-6 tracking-tight text-white">
+            Got a rooftop, a tower, or a high spot?{' '}
+            <span className="bg-gradient-to-r from-[var(--success-500)] to-[var(--info-600)] bg-clip-text text-transparent">
+              We need you.
+            </span>
+          </h1>
+          <p className="text-xl text-white/70 leading-relaxed">
+            Hosted infrastructure is the single biggest thing standing between KC Mesh today and KC Mesh covering the whole metro. If you have elevation and a willing outlet, we'd love to talk.
+          </p>
+        </div>
+      </div>
+
+      {/* Article */}
+      <article className="px-4 py-16 max-w-3xl mx-auto">
+
+        {/* Why this matters */}
+        <section className="mb-16">
+          <h2 className="text-white mb-6">Why hosted infrastructure matters</h2>
+
+          <p className="text-white/70 mb-6 leading-relaxed">
+            KC Mesh has 60+ active nodes today. Most of them are client nodes — handhelds, indoor home setups, T-Decks in backpacks. They're great for local conversations, but client-only density doesn't carry a message from Liberty to Olathe.
+          </p>
+
+          <p className="text-white/70 mb-6 leading-relaxed">
+            What does carry that message is a small number of router nodes mounted high, with clear sky, running 24/7. The plan is four of them: East, West, North, and South. Together they form what we're calling the <strong>KC Backbone Initiative</strong> — the spine that turns a bunch of friendly hobbyist nodes into a metro-wide network.
+          </p>
+
+          <div className="tip-banner flex gap-3 p-4">
+            <Info className="w-5 h-5 text-[var(--success-500)] flex-shrink-0 mt-0.5" />
+            <p className="text-white/80 leading-relaxed">
+              <strong>The West side is the current critical gap.</strong> If you own or manage a building, billboard, tower, or rooftop anywhere from Lenexa west to the state line, you might be exactly the host we've been looking for.
+            </p>
+          </div>
+        </section>
+
+        {/* What makes a great host site */}
+        <section className="mb-16">
+          <h2 className="text-white mb-6">What makes a great host site</h2>
+
+          <p className="text-white/70 mb-8 leading-relaxed">
+            Honest list. If your site checks most of these, please get in touch — we can work around the rest.
+          </p>
+
+          <div className="space-y-4 mb-8">
+            <div className="bg-[var(--neutral-900)] border border-white/10 rounded-xl p-6">
+              <h3 className="text-white mb-2 flex items-center gap-2">
+                <MapPin className="w-5 h-5 text-[var(--success-500)]" />
+                Elevation — 15 feet and up
+              </h3>
+              <p className="text-white/60 leading-relaxed">
+                You don't need a 40-foot tower. A two-story roof works. A flagpole works. An attic with a clear southern exposure can work. The dogma about needing massive elevation is just dogma — get above the immediate clutter and you're already useful.
+              </p>
+            </div>
+
+            <div className="bg-[var(--neutral-900)] border border-white/10 rounded-xl p-6">
+              <h3 className="text-white mb-2 flex items-center gap-2">
+                <Radio className="w-5 h-5 text-[var(--success-500)]" />
+                Sky that's not blocked by another building
+              </h3>
+              <p className="text-white/60 leading-relaxed">
+                LoRa at 915 MHz mostly cares about line of sight. If you can see other rooftops and the horizon in at least one direction, signals will travel. We'll help you pick the antenna and aim.
+              </p>
+            </div>
+
+            <div className="bg-[var(--neutral-900)] border border-white/10 rounded-xl p-6">
+              <h3 className="text-white mb-2 flex items-center gap-2">
+                <span className="w-5 h-5 text-[var(--success-500)] flex items-center justify-center">⚡</span>
+                A 120V outlet — or room for a small solar panel
+              </h3>
+              <p className="text-white/60 leading-relaxed">
+                A wired node draws less power than a wifi router. Don't have an outlet on the roof? A 10W solar panel and a small battery run a node indefinitely. We've got documented setups for both.
+              </p>
+            </div>
+
+            <div className="bg-[var(--neutral-900)] border border-white/10 rounded-xl p-6">
+              <h3 className="text-white mb-2 flex items-center gap-2">
+                <span className="w-5 h-5 text-[var(--success-500)] flex items-center justify-center">🔧</span>
+                Willingness to host modest hardware
+              </h3>
+              <p className="text-white/60 leading-relaxed">
+                We're talking about a $60–$200 device the size of a paperback, plus a small antenna. Not commercial telecom gear. Weekend-project scale. If something breaks, the worst case is somebody comes out and swaps the box.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Who should consider hosting */}
+        <section className="mb-16">
+          <h2 className="text-white mb-6">Who should consider hosting</h2>
+
+          <p className="text-white/70 mb-8 leading-relaxed">
+            If you see yourself in any of these, you're exactly who we're trying to reach.
+          </p>
+
+          <div className="grid sm:grid-cols-2 gap-4 mb-8">
+            {hostTypes.map((host, index) => (
+              <div
+                key={index}
+                className="relative bg-white/5 border border-white/10 rounded-2xl p-6 transition-all hover:bg-white/10 hover:border-white/20 hover:-translate-y-1"
+              >
+                <div className={`w-12 h-12 rounded-xl flex items-center justify-center mb-4 bg-gradient-to-br ${host.color}`}>
+                  {host.icon}
+                </div>
+                <h3 className="text-lg text-white mb-2">{host.name}</h3>
+                <p className="text-white/60 text-[15px] leading-relaxed">{host.description}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* What KC Mesh provides */}
+        <section className="mb-16">
+          <h2 className="text-white mb-6">What KC Mesh provides in return</h2>
+
+          <p className="text-white/70 mb-8 leading-relaxed">
+            This is a hobbyist project, not a vendor relationship. But here's what we bring to the table:
+          </p>
+
+          <div className="space-y-4">
+            <div className="bg-[var(--neutral-900)] border border-white/10 rounded-xl p-6">
+              <h3 className="text-white mb-2">Equipment guidance — and sometimes the equipment itself</h3>
+              <p className="text-white/60 leading-relaxed">
+                We'll pick hardware that fits your site, your power situation, and your budget. For priority backbone locations, we can usually find someone in the community willing to donate or split the cost of the device.
+              </p>
+            </div>
+
+            <div className="bg-[var(--neutral-900)] border border-white/10 rounded-xl p-6">
+              <h3 className="text-white mb-2">Hands-on deployment help</h3>
+              <p className="text-white/60 leading-relaxed">
+                Someone from the community will come out, mount the antenna, configure the node, and confirm it's healthy on the mesh. You don't need to learn LoRa to host one.
+              </p>
+            </div>
+
+            <div className="bg-[var(--neutral-900)] border border-white/10 rounded-xl p-6">
+              <h3 className="text-white mb-2">Ongoing monitoring via Discord</h3>
+              <p className="text-white/60 leading-relaxed">
+                If your node falls off the mesh, somebody in the Discord will notice — usually within an hour. We'll let you know and help you bring it back up.
+              </p>
+            </div>
+
+            <div className="bg-[var(--neutral-900)] border border-white/10 rounded-xl p-6">
+              <h3 className="text-white mb-2">Public credit on the coverage map</h3>
+              <p className="text-white/60 leading-relaxed">
+                Your site shows up on <a href="https://map.kansascitymesh.live" target="_blank" rel="noopener noreferrer" className="text-[var(--success-500)] hover:underline">map.kansascitymesh.live</a> as a contributing backbone node. If you're a business, we'll happily call you out by name; if you'd rather be anonymous, we don't have to.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* First success story */}
+        <section className="mb-16">
+          <h2 className="text-white mb-6">What this looks like in practice</h2>
+
+          <div className="message-banner">
+            <p className="text-white/70 mb-4 leading-relaxed">
+              Right now the proof-of-concept is my own router. It's a Heltec V3 in a weatherproof box, mounted about 25 feet up, drawing power from a regular outdoor outlet. Total hardware cost was under $100. Total install time was an afternoon.
+            </p>
+
+            <p className="text-white/70 mb-4 leading-relaxed">
+              It's been online for months. It hands off traffic between client nodes that can't hear each other directly. It made the difference between "a few people messing around" and "a network."
+            </p>
+
+            <p className="text-white/70 leading-relaxed">
+              We need three more. East, West, North, South. That's the whole ask.
+            </p>
+          </div>
+        </section>
+
+        {/* Get in touch */}
+        <section className="mb-16 pt-8 border-t border-white/10">
+          <h2 className="text-white mb-6">Get in touch</h2>
+
+          <p className="text-white/70 mb-8 leading-relaxed">
+            If you've got a site that sounds like it might fit — or you just want to talk it through to find out — please reach out. The fastest path is email, but Discord works too.
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 mb-8">
+            <a
+              href={`mailto:${HOST_EMAIL}?subject=KC%20Backbone%20Initiative%20%E2%80%94%20potential%20host%20site`}
+              onClick={() => trackEvent('host_email_click', 'host-page-cta')}
+              className="inline-flex items-center justify-center gap-2 px-6 py-3.5 bg-[var(--success-500)] text-black rounded-xl font-medium text-[15px] transition-all hover:bg-[var(--success-600)] hover:text-white hover:scale-105 hover:shadow-2xl active:scale-100"
+            >
+              Email about a host site
+            </a>
+
+            <DiscordButton href={DISCORD_INVITE} trackingLabel="host-page-discord">
+              Or come say hi in Discord
+            </DiscordButton>
+          </div>
+
+          <p className="text-white/50 text-sm leading-relaxed">
+            Not sure yet? No problem. The Discord is open — lurk for a while, see what people are doing, and circle back whenever it makes sense.
+          </p>
+        </section>
+
+      </article>
+
+      <Footer onNavigate={onNavigate} />
+    </div>
+  );
+}

--- a/src/components/HostANodePage.tsx
+++ b/src/components/HostANodePage.tsx
@@ -15,7 +15,7 @@ const HOST_EMAIL = 'hello@orangefla.me';
 const hostTypes = [
   {
     name: 'Businesses with rooftops',
-    description: "Warehouses, retail strip centers, offices. If you have a flat roof and a 120V outlet on it, you have what we need. We're especially looking on the West side of the metro.",
+    description: "Warehouses, retail strip centers, offices. If you have a flat roof and a 120V outlet on it, you have what we need. We're especially looking in Bonner Springs, Independence, and Blue Springs — plus any spot along I-70 (east or west) where a hop helps connect existing outlier nodes in Manhattan and Columbia back to the KC mesh.",
     icon: <Building2 className="w-6 h-6 text-white" />,
     color: 'from-[var(--primary-600)] to-[var(--primary-800)]',
   },
@@ -103,18 +103,27 @@ export default function HostANodePage({ onNavigate }: HostANodePageProps) {
           <h2 className="text-white mb-6">Why hosted infrastructure matters</h2>
 
           <p className="text-white/70 mb-6 leading-relaxed">
-            KC Mesh has 60+ active nodes today. Most of them are client nodes — handhelds, indoor home setups, T-Decks in backpacks. They're great for local conversations, but client-only density doesn't carry a message from Liberty to Olathe.
+            KC Mesh has 60+ active nodes today, and we've built a strong spine running up and down the I-35 corridor — messages move cleanly between downtown, Westport, Overland Park, and the southern suburbs. That spine is real progress, and it's the foundation everything else builds on.
           </p>
 
           <p className="text-white/70 mb-6 leading-relaxed">
-            What does carry that message is a small number of router nodes mounted high, with clear sky, running 24/7. The plan is four of them: East, West, North, and South. Together they form what we're calling the <strong>KC Backbone Initiative</strong> — the spine that turns a bunch of friendly hobbyist nodes into a metro-wide network.
+            What we don't yet have is a mesh that reaches the metro's east and west edges, much less the cities just outside it. Most of our 60+ nodes are client nodes — handhelds, indoor home setups, T-Decks in backpacks — and client-only density doesn't carry a message from Westport to Blue Springs.
+          </p>
+
+          <p className="text-white/70 mb-6 leading-relaxed">
+            The fix is a small number of router nodes mounted high, with clear sky, running 24/7. We're calling the rollout the <strong>KC Backbone Initiative</strong>, and it has two parallel asks:
           </p>
 
           <div className="tip-banner flex gap-3 p-4">
             <Info className="w-5 h-5 text-[var(--success-500)] flex-shrink-0 mt-0.5" />
-            <p className="text-white/80 leading-relaxed">
-              <strong>The West side is the current critical gap.</strong> If you own or manage a building, billboard, tower, or rooftop anywhere from Lenexa west to the state line, you might be exactly the host we've been looking for.
-            </p>
+            <div className="space-y-4 text-white/80 leading-relaxed">
+              <p>
+                <strong>1. Round out the metro.</strong> Bonner Springs on the west side. Independence and Blue Springs to the east. These are the gaps where messages from downtown die before they reach you.
+              </p>
+              <p>
+                <strong>2. Close the chain to the outliers.</strong> There are already nodes on the map as far out as Manhattan, KS and Columbia, MO — but they can't reliably reach the KC mesh because the hop chain between them and downtown doesn't exist yet. Lawrence, Topeka, Lee's Summit, Warrensburg — every host along I-70 in either direction is a link that makes those far-out nodes part of the network.
+              </p>
+            </div>
           </div>
         </section>
 
@@ -246,7 +255,7 @@ export default function HostANodePage({ onNavigate }: HostANodePageProps) {
             </p>
 
             <p className="text-white/70 leading-relaxed">
-              We need three more. East, West, North, South. That's the whole ask.
+              We need more like it — out at the edges, and along I-70 in both directions to close the chain to the existing outliers. That's the whole ask.
             </p>
           </div>
         </section>

--- a/src/components/HostInfrastructureCTA.tsx
+++ b/src/components/HostInfrastructureCTA.tsx
@@ -1,0 +1,49 @@
+import { ArrowRight, Signal } from 'lucide-react';
+
+interface HostInfrastructureCTAProps {
+  onNavigate: (target: 'home' | 'get-started' | 'host') => void;
+}
+
+export default function HostInfrastructureCTA({ onNavigate }: HostInfrastructureCTAProps) {
+  return (
+    <section className="px-4 py-16 bg-black border-t border-white/10 relative overflow-hidden">
+      <div className="absolute inset-0 -z-10">
+        <div
+          className="absolute top-1/2 left-1/4 w-96 h-96 rounded-full blur-3xl"
+          style={{ backgroundColor: 'var(--success-500)', opacity: 0.18 }}
+        ></div>
+        <div
+          className="absolute top-0 right-1/4 w-80 h-80 rounded-full blur-3xl"
+          style={{ backgroundColor: 'var(--secondary-600)', opacity: 0.18 }}
+        ></div>
+      </div>
+
+      <div className="max-w-4xl mx-auto">
+        <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-8 md:p-10 shadow-xl shadow-black/50">
+          <div className="flex flex-col md:flex-row md:items-center gap-6">
+            <div className="flex-shrink-0 w-14 h-14 bg-[var(--success-500)]/20 rounded-2xl flex items-center justify-center">
+              <Signal className="w-7 h-7 text-[var(--success-500)]" />
+            </div>
+
+            <div className="flex-1">
+              <h2 className="text-2xl md:text-3xl text-white mb-2 tracking-tight">
+                Got a rooftop, a tower, or a high spot in the metro?
+              </h2>
+              <p className="text-white/70 leading-relaxed">
+                We're recruiting hosts for the KC Backbone Initiative — the four-router spine that turns a bunch of friendly nodes into a metro-wide network. The West side is the current critical gap.
+              </p>
+            </div>
+
+            <button
+              onClick={() => onNavigate('host')}
+              className="inline-flex items-center justify-center gap-2 px-6 py-3.5 bg-[var(--success-500)] text-black rounded-xl font-medium text-[15px] transition-all hover:bg-[var(--success-600)] hover:text-white hover:scale-105 hover:shadow-2xl active:scale-100 flex-shrink-0"
+            >
+              <span>Become a host</span>
+              <ArrowRight className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/HostInfrastructureCTA.tsx
+++ b/src/components/HostInfrastructureCTA.tsx
@@ -30,7 +30,7 @@ export default function HostInfrastructureCTA({ onNavigate }: HostInfrastructure
                 Got a rooftop, a tower, or a high spot in the metro?
               </h2>
               <p className="text-white/70 leading-relaxed">
-                We're recruiting hosts for the KC Backbone Initiative — the four-router spine that turns a bunch of friendly nodes into a metro-wide network. The West side is the current critical gap.
+                We're recruiting hosts for the KC Backbone Initiative — hosted nodes that fill the metro's east and west edges (Bonner Springs, Independence, Blue Springs) and close the I-70 hop chain out to existing outlier nodes in Manhattan and Columbia.
               </p>
             </div>
 

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -6,8 +6,8 @@ import { DISCORD_INVITE } from '../constants/discord';
 import { trackEvent } from '../utils/analytics';
 
 interface NavProps {
-  onNavigate: (target: 'home' | 'get-started') => void;
-  currentPage?: 'home' | 'get-started';
+  onNavigate: (target: 'home' | 'get-started' | 'host') => void;
+  currentPage?: 'home' | 'get-started' | 'host';
 }
 
 export default function Nav({ onNavigate, currentPage = 'home' }: NavProps) {
@@ -22,8 +22,8 @@ export default function Nav({ onNavigate, currentPage = 'home' }: NavProps) {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  // Force dark background on Get Started page, transparent on home
-    const navBackground = currentPage === 'get-started' || isScrolled
+  // Force dark background on Get Started / Host pages, transparent on home
+    const navBackground = currentPage !== 'home' || isScrolled
       ? 'bg-black/80 backdrop-blur-xl border-b border-white/10 shadow-lg shadow-black/20'
       : 'bg-transparent';
 
@@ -44,21 +44,31 @@ export default function Nav({ onNavigate, currentPage = 'home' }: NavProps) {
 
           {/* Right: Navigation */}
           <div className="flex items-center gap-3 md:gap-6">
-            <a 
-              href="https://map.kansascitymesh.live" 
-              target="_blank" 
+            <a
+              href="https://map.kansascitymesh.live"
+              target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-1 text-sm text-white/70 hover:text-white transition-colors hidden md:flex"
             >
               <span>Coverage Map</span>
               <ExternalLink className="w-3.5 h-3.5 transition-transform group-hover/btn:translate-x-0.5 group-hover/btn:-translate-y-0.5" />
             </a>
-              <button 
-                onClick={() => onNavigate(currentPage === 'home' ? 'get-started' : 'home')}
-                className="text-sm text-white/70 hover:text-white transition-colors hidden sm:block"
-              >
-                {currentPage === 'get-started' ? 'Home' : 'Get Started'}
-              </button>
+            <button
+              onClick={() => onNavigate('host')}
+              className={`text-sm transition-colors hidden md:block ${
+                currentPage === 'host' ? 'text-white' : 'text-white/70 hover:text-white'
+              }`}
+            >
+              Host a Node
+            </button>
+            <button
+              onClick={() => onNavigate(currentPage === 'get-started' ? 'home' : 'get-started')}
+              className={`text-sm transition-colors hidden sm:block ${
+                currentPage === 'get-started' ? 'text-white' : 'text-white/70 hover:text-white'
+              }`}
+            >
+              {currentPage === 'get-started' ? 'Home' : 'Get Started'}
+            </button>
             <a
               href={DISCORD_INVITE}
               target="_blank"


### PR DESCRIPTION
## Summary

The Discord just crossed **200 members** and a Cascadia Mesh community member pointed us at [cascadiamesh.org](https://cascadiamesh.org/) as a model for growth — especially for getting **businesses and infrastructure hosts** to participate. This PR adapts the most useful parts of their playbook for KC.

- **New `/host-a-node` page** recruiting infrastructure hosts under the **KC Backbone Initiative** (the four-router East/West/North/South spine from `CLAUDE.md`, elevated from internal plan to public flagship project name). Leads with the West-side gap as the current critical ask.
- **Hero stat update** — surfaces `200+ in Discord` alongside the existing node counts as social proof.
- **Homepage CTA section** (`HostInfrastructureCTA`) between Resources and Final CTA — single-sentence pitch + button to the new page. Doesn't disturb the existing flow.
- **`docs/COMMUNITY-GROWTH-PLAYBOOK.md`** — Jeremy's private strategy doc. Synthesizes what Cascadia does well (flagship corridor initiative, concrete site requirements, anchor case study, sister 501(c)(3), dedicated host email, multi-audience welcome language), what we adopt now, and what we explicitly defer (nonprofit formation until 3+ hosted sites; regional sub-mesh model until adjacent metros ask).

## What's targeted at hosts

The Host a Node page is built around audience cards naming every kind of host we want — **businesses with rooftops, ham operators & repeater owners, churches/schools/civic buildings, billboard/water-tower/cell-tower owners, building managers & flagpole homeowners** — plus concrete site requirements (15+ ft elevation, clear sky, 120V or solar, modest hardware) so a building owner can self-qualify in 30 seconds. CTA is a `mailto:` to the project email (separate channel from the Discord firehose) with a Discord softer secondary CTA.

## Voice

Follows `AGENTS.md` — first-person, field-log tone, anti-perfectionism callouts (15 ft is fine, $60 hardware is fine, weekend project not commercial-grade). Reuses existing `DiscordButton`, `PulsingDot`, color CSS variables, translucent-card styling. No new design tokens.

## Files

**Created**
- `src/components/HostANodePage.tsx`
- `src/components/HostInfrastructureCTA.tsx`
- `host-a-node.html` (SEO meta shell, mirrors `getting-started.html`)
- `docs/COMMUNITY-GROWTH-PLAYBOOK.md`

**Modified**
- `src/App.tsx` — widen `Page` union to include `'host'`, route `/host-a-node`, scroll-to-top on navigate
- `src/components/Nav.tsx` — widen `onNavigate`, add Host a Node link (md+ viewports)
- `src/components/Footer.tsx` — widen `onNavigate`, add Host a Node link
- `src/components/HomePage.tsx` — render the new CTA section
- `src/components/GetStartedPage.tsx` — widen `onNavigate` signature
- `src/components/HeroSection.tsx` — append `200+ in Discord.` to the stat line

## Test plan

- [ ] `npm run check` — TypeScript clean (passed locally)
- [ ] `npm run build` — production bundle builds (passed locally; 187 KB JS gzipped to 57 KB, no new dependencies)
- [ ] `npm run dev` and visit `/` — confirm hero now reads `60+ active nodes. 130+ total nodes. 200+ in Discord.`
- [ ] Click Nav "Host a Node" link — URL updates to `/host-a-node`, page renders, scrolls to top
- [ ] Click `<HostInfrastructureCTA>` button on home — navigates to `/host-a-node`
- [ ] Click email CTA on host page — opens `mailto:` to `hello@orangefla.me` with prefilled subject
- [ ] Walk the page on mobile (≤375 px), tablet (768 px), and desktop (1440 px) — host-type cards reflow from 1 to 2 columns, CTAs stay tappable
- [ ] Browser back/forward — popstate handler returns to previous page
- [ ] Reload directly on `/host-a-node` — SPA fallback renders the page

## Out of scope

- 501(c)(3) formation (deferred per playbook — trigger conditions in the doc)
- Regional sub-mesh / federation model (deferred until adjacent metros ask)
- Coverage-map integration beyond the existing external link
- Discord bot / email automation

https://claude.ai/code/session_01SAcStgNjHoasU8Pjsx9NLn

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAcStgNjHoasU8Pjsx9NLn)_