### PR TITLE
ci: add GitHub Actions for typecheck + build on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel in-progress runs when a new commit lands on the same branch/PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Typecheck + build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run check
+
+      - name: Build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kansas City Meshtastic Network
 
+[![CI](https://github.com/jeremyfuksa/kansascitymesh.live/actions/workflows/ci.yml/badge.svg)](https://github.com/jeremyfuksa/kansascitymesh.live/actions/workflows/ci.yml)
+
 The website for the community-run Meshtastic mesh network in the Kansas City metro. Live at [kansascitymesh.live](https://kansascitymesh.live). Source under CC-BY-SA 4.0 — fork it for your own city.
 
 ## Tech stack


### PR DESCRIPTION
## Summary

Adds CI to the repo. A single job runs `npm run check` (TypeScript) and `npm run build` (Vite production build) on every PR and every push to `main`.

This is foundation for landing the upcoming major-version migrations (React 19, Tailwind 4, Vite 8, TypeScript 6) safely — each of those changes has real breakage risk, and having CI verify each migration PR independently catches regressions before merge.

## What's in this PR

- `.github/workflows/ci.yml` — single workflow, single job, two steps after install
- CI status badge added to README near the title

## Workflow design

| Choice | Why |
|---|---|
| Node 22 LTS | Matches Vite 7's tested range (Vite 7 requires Node 20.19+ or 22.12+) |
| `npm ci` not `npm install` | Fails fast if `package-lock.json` is out of sync with `package.json`; faster than install in CI |
| One job, two steps | Typecheck and build share the `npm ci` install (~30s); running both as steps in one job is faster than two parallel jobs that each install |
| `actions/setup-node@v4` with `cache: 'npm'` | Caches `~/.npm` based on `package-lock.json` hash |
| `concurrency.cancel-in-progress: true` | When a new commit lands on the same PR, the in-flight run gets canceled. Saves Actions minutes |
| `permissions: contents: read` | Least-privilege; nothing here needs write access |

## What this PR does NOT do

- No tests — the project doesn't have any yet. When tests get added, drop a `Test` step between Typecheck and Build (or split into its own job if the suite gets slow).
- No lint or format check — would require also installing/configuring ESLint and Prettier. Deferred. Easy to add later.
- No `npm audit` step — Dependabot already covers this on a different cadence; running it in CI would create noise.
- **No branch protection rule.** That has to be configured in GitHub settings (or via API). After this PR merges, branch protection on `main` should be enabled requiring the new "Typecheck + build" check to pass before merge.

## Test plan

- [ ] CI runs on this PR (this is the first run — if it passes here, the workflow itself is validated)
- [ ] After merge, enable branch protection on `main` requiring the "Typecheck + build" status check
- [ ] On the next PR (the React 19 migration, presumably), confirm CI runs automatically and gates merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)