### PR TITLE
feat(design-system): PR 2 — tighten radii one notch

### DIFF
--- a/src/components/AudienceRow.astro
+++ b/src/components/AudienceRow.astro
@@ -10,12 +10,12 @@ const { accent, name, description } = Astro.props;
 ---
 
 <div
-  class="relative bg-[var(--neutral-900)] border border-white/10 rounded-xl overflow-hidden hover:border-white/20 transition-colors"
+  class="relative bg-[var(--neutral-900)] border border-white/10 rounded-md overflow-hidden hover:border-white/20 transition-colors"
 >
   <div class={`absolute top-0 bottom-0 left-0 w-1 bg-gradient-to-b ${accent}`}></div>
   <div class="flex gap-4 p-6 pl-7">
     <div
-      class="flex-shrink-0 w-10 h-10 rounded-lg bg-white/5 flex items-center justify-center"
+      class="flex-shrink-0 w-10 h-10 rounded-sm bg-white/5 flex items-center justify-center"
     >
       <slot name="icon" />
     </div>

--- a/src/components/DiscordButton.astro
+++ b/src/components/DiscordButton.astro
@@ -12,10 +12,10 @@ const { href, size = 'default', trackLabel = 'discord-invite' } = Astro.props;
 
 const sizeClasses =
   size === 'large'
-    ? 'px-8 py-5 text-[17px] rounded-xl'
+    ? 'px-8 py-5 text-[17px] rounded-lg'
     : size === 'small'
-      ? 'px-3 md:px-4 py-2 text-sm rounded-lg'
-      : 'px-6 py-3.5 text-[15px] rounded-xl';
+      ? 'px-3 md:px-4 py-2 text-sm rounded-sm'
+      : 'px-6 py-3.5 text-[15px] rounded-md';
 
 // Small size uses a quieter hover (color only, no scale) since it lives in nav contexts.
 const hoverClasses =

--- a/src/components/DroneFlyCTA.astro
+++ b/src/components/DroneFlyCTA.astro
@@ -18,7 +18,7 @@ import { DISCORD_INVITE } from '../constants/discord';
     <FeatureCard padding="large">
       <div class="flex flex-col md:flex-row md:items-start gap-6">
         <div
-          class="flex-shrink-0 w-14 h-14 bg-[var(--info-600)]/20 rounded-2xl flex items-center justify-center"
+          class="flex-shrink-0 w-14 h-14 bg-[var(--info-600)]/20 rounded-lg flex items-center justify-center"
         >
           <Plane class="w-7 h-7 text-[var(--info-600)]" />
         </div>

--- a/src/components/FeatureCard.astro
+++ b/src/components/FeatureCard.astro
@@ -40,7 +40,7 @@ const {
   padding = 'default',
 } = Astro.props;
 
-const base = `bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl ${PADDING_CLASSES[padding]} shadow-xl shadow-black/50`;
+const base = `bg-white/5 backdrop-blur-xl border border-white/10 rounded-lg ${PADDING_CLASSES[padding]} shadow-xl shadow-black/50`;
 const hover = interactive
   ? ' hover:bg-white/10 hover:border-white/20 hover:-translate-y-1 transition-all'
   : '';

--- a/src/components/FinalCTASection.astro
+++ b/src/components/FinalCTASection.astro
@@ -34,7 +34,7 @@ import { Radio } from '@lucide/astro';
 
   <div class="max-w-3xl mx-auto text-center relative">
     <div
-      class="inline-flex items-center justify-center w-16 h-16 bg-white/10 backdrop-blur-sm rounded-2xl mb-8 border border-white/20"
+      class="inline-flex items-center justify-center w-16 h-16 bg-white/10 backdrop-blur-sm rounded-lg mb-8 border border-white/20"
     >
       <Radio class="w-8 h-8 text-[var(--success-500)]" />
     </div>

--- a/src/components/HardwareCard.astro
+++ b/src/components/HardwareCard.astro
@@ -14,11 +14,11 @@ const { name, price, badge, description, color, image } = Astro.props;
 ---
 
 <div
-  class="group relative bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl overflow-hidden shadow-xl shadow-black/50 hover:bg-white/10 hover:border-white/20 hover:-translate-y-1 transition-all"
+  class="group relative bg-white/5 backdrop-blur-xl border border-white/10 rounded-lg overflow-hidden shadow-xl shadow-black/50 hover:bg-white/10 hover:border-white/20 hover:-translate-y-1 transition-all"
 >
   {/* Gradient accent */}
   <div
-    class={`absolute top-0 left-0 right-0 h-1.5 bg-gradient-to-r ${color} rounded-t-2xl z-10`}
+    class={`absolute top-0 left-0 right-0 h-1.5 bg-gradient-to-r ${color} rounded-t-lg z-10`}
   >
   </div>
 
@@ -38,7 +38,7 @@ const { name, price, badge, description, color, image } = Astro.props;
         <span class="text-2xl text-white">{price}</span>
       </div>
       <span
-        class={`px-3 py-1 bg-gradient-to-r ${color} text-white rounded-xl text-sm font-medium`}
+        class={`px-3 py-1 bg-gradient-to-r ${color} text-white rounded-md text-sm font-medium`}
       >
         {badge}
       </span>

--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -51,7 +51,7 @@ import { DISCORD_INVITE } from '../constants/discord';
       <FeatureCard padding="wide" class="flex flex-col">
         <div class="flex items-start gap-4 mb-6 pb-6 border-b border-white/10">
           <div
-            class="w-10 h-10 bg-[var(--success-500)]/20 rounded-xl flex items-center justify-center flex-shrink-0"
+            class="w-10 h-10 bg-[var(--success-500)]/20 rounded-md flex items-center justify-center flex-shrink-0"
           >
             <Radio class="w-5 h-5 text-[var(--success-500)]" />
           </div>

--- a/src/components/HostInfrastructureCTA.astro
+++ b/src/components/HostInfrastructureCTA.astro
@@ -22,7 +22,7 @@ import PrimaryButton from './PrimaryButton.astro';
     <FeatureCard padding="large">
       <div class="flex flex-col md:flex-row md:items-center gap-6">
         <div
-          class="flex-shrink-0 w-14 h-14 bg-[var(--success-500)]/20 rounded-2xl flex items-center justify-center"
+          class="flex-shrink-0 w-14 h-14 bg-[var(--success-500)]/20 rounded-lg flex items-center justify-center"
         >
           <Signal class="w-7 h-7 text-[var(--success-500)]" />
         </div>

--- a/src/components/InfoCard.astro
+++ b/src/components/InfoCard.astro
@@ -18,7 +18,7 @@ const PADDING_CLASSES: Record<PaddingSize, string> = {
 };
 
 const { class: className = '', interactive = false, padding = 'default' } = Astro.props;
-const base = `bg-[var(--neutral-900)] border border-white/10 rounded-xl ${PADDING_CLASSES[padding]}`;
+const base = `bg-[var(--neutral-900)] border border-white/10 rounded-md ${PADDING_CLASSES[padding]}`;
 const hover = interactive ? ' hover:border-white/20 transition-colors' : '';
 ---
 

--- a/src/components/MessageBanner.astro
+++ b/src/components/MessageBanner.astro
@@ -4,7 +4,7 @@
 ---
 
 <div
-  class="relative overflow-hidden rounded-2xl p-8"
+  class="relative overflow-hidden rounded-lg p-8"
   style="background: linear-gradient(180deg, rgba(15, 23, 42, 0.9), rgba(12, 15, 19, 0.95)); border: 1px solid rgba(255, 255, 255, 0.12); box-shadow: 0 25px 55px rgba(0, 0, 0, 0.35);"
 >
   <div class="relative z-10">

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -36,7 +36,7 @@ const linkClass = (active: boolean) =>
     <div class="flex items-center justify-between gap-4">
       {/* Left: Brand/Status */}
       <div class="flex items-center gap-2 md:gap-3">
-        <img src={logo.src} alt="KC Mesh" class="w-8 h-8 rounded-lg" />
+        <img src={logo.src} alt="KC Mesh" class="w-8 h-8 rounded-sm" />
         <div
           class="flex items-center gap-2 px-3 py-1.5 bg-white/10 backdrop-blur-sm rounded-full border border-white/20"
         >

--- a/src/components/PrimaryButton.astro
+++ b/src/components/PrimaryButton.astro
@@ -10,7 +10,7 @@ interface Props {
 
 const { href, external = false, trackEvent, trackLabel } = Astro.props;
 const className =
-  'inline-flex items-center justify-center gap-2 px-6 py-3.5 bg-[var(--success-500)] text-black rounded-xl font-medium text-[15px] transition-all hover:bg-[var(--success-600)] hover:text-white hover:scale-105 hover:shadow-2xl active:scale-100';
+  'inline-flex items-center justify-center gap-2 px-6 py-3.5 bg-[var(--success-500)] text-black rounded-md font-medium text-[15px] transition-all hover:bg-[var(--success-600)] hover:text-white hover:scale-105 hover:shadow-2xl active:scale-100';
 ---
 
 {

--- a/src/components/ResourcesSection.astro
+++ b/src/components/ResourcesSection.astro
@@ -53,7 +53,7 @@ const resources = [
             >
               <div class="flex items-start gap-4 mb-4">
                 <div
-                  class={`w-12 h-12 rounded-xl flex items-center justify-center flex-shrink-0 bg-gradient-to-br ${resource.color}`}
+                  class={`w-12 h-12 rounded-md flex items-center justify-center flex-shrink-0 bg-gradient-to-br ${resource.color}`}
                 >
                   <Icon class="w-6 h-6 text-white" />
                 </div>

--- a/src/components/SecondaryButton.astro
+++ b/src/components/SecondaryButton.astro
@@ -8,7 +8,7 @@ interface Props {
 
 const { href, external = false, trackEvent, trackLabel } = Astro.props;
 const className =
-  'inline-flex items-center gap-2 px-5 py-3 bg-white/5 border border-white/10 text-white rounded-xl hover:bg-white/10 hover:border-white/20 transition-all text-sm font-medium';
+  'inline-flex items-center gap-2 px-5 py-3 bg-white/5 border border-white/10 text-white rounded-md hover:bg-white/10 hover:border-white/20 transition-all text-sm font-medium';
 ---
 
 {

--- a/src/components/TipBanner.astro
+++ b/src/components/TipBanner.astro
@@ -3,7 +3,7 @@ import { Info } from '@lucide/astro';
 ---
 
 <div
-  class="relative overflow-hidden rounded-2xl p-6 flex gap-3"
+  class="relative overflow-hidden rounded-lg p-6 flex gap-3"
   style="background: linear-gradient(135deg, rgba(127, 197, 63, 0.12), rgba(32, 61, 35, 0.5)); border: 1px solid rgba(143, 177, 75, 0.5); box-shadow: 0 20px 45px rgba(6, 16, 5, 0.45);"
 >
   <div class="flex-shrink-0 mt-0.5">

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -7,6 +7,12 @@ module.exports = {
         sans: ['General Sans', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'sans-serif'],
         mono: ['Inconsolata', 'ui-monospace', 'SFMono-Regular', 'monospace'],
       },
+      borderRadius: {
+        'xs': '0.25rem',   // 4px  — inline chips, code spans
+        'sm': '0.375rem',  // 6px  — small DiscordButton, logo, inputs
+        'md': '0.625rem',  // 10px — InfoCard, default buttons, status pill icon container
+        'lg': '0.75rem',   // 12px — FeatureCard, HardwareCard, TipBanner, MessageBanner
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary

PR 2 of the staged design system migration in `KC Mesh Design System/MIGRATION.md`. Cosmetic only — every existing rounded surface drops one notch tighter so the visual rhythm reads as "field log" rather than "rounded SaaS."

Stacked on #20 (PR 1).

## What changed

Tailwind theme override (`theme.extend.borderRadius`):
- `xs` = 4px, `sm` = 6px, `md` = 10px, `lg` = 12px

Matches DESIGN.md's `--radius-*` scale.

| Component | Before | After |
|---|---|---|
| FeatureCard | `rounded-2xl` 16 | `rounded-lg` 12 |
| HardwareCard | `rounded-2xl` 16 | `rounded-lg` 12 |
| TipBanner | `rounded-2xl` 16 | `rounded-lg` 12 |
| MessageBanner | `rounded-2xl` 16 | `rounded-lg` 12 |
| InfoCard | `rounded-xl` 12 | `rounded-md` 10 |
| AudienceRow | `rounded-xl` 12 | `rounded-md` 10 |
| PrimaryButton | `rounded-xl` 12 | `rounded-md` 10 |
| SecondaryButton | `rounded-xl` 12 | `rounded-md` 10 |
| DiscordButton default | `rounded-xl` 12 | `rounded-md` 10 |
| DiscordButton small | `rounded-lg` 8 | `rounded-sm` 6 |
| DiscordButton large | `rounded-xl` 12 | `rounded-lg` 12 |
| Nav logo | `rounded-lg` 8 | `rounded-sm` 6 |
| Hero icon medallion | `rounded-xl` 12 | `rounded-md` 10 |
| Host CTA medallion | `rounded-2xl` 16 | `rounded-lg` 12 |
| Drone CTA medallion | `rounded-2xl` 16 | `rounded-lg` 12 |
| Final CTA medallion | `rounded-2xl` 16 | `rounded-lg` 12 |
| Hardware badge | `rounded-xl` 12 | `rounded-md` 10 |
| Hardware accent stripe | `rounded-t-2xl` | `rounded-t-lg` |
| AudienceRow inner icon | `rounded-lg` 8 | `rounded-sm` 6 |
| Resources medallion | `rounded-xl` 12 | `rounded-md` 10 |

## Unchanged

- Status pills (`rounded-full`)
- Getting Started step circles (`rounded-full`)
- DroneFlyCTA inline `<code>` (already at default Tailwind `rounded` = 4 px, the xs tier)

## Test plan

- [x] `npm run check` — 0 errors / 0 warnings / 41 files
- [x] `npm run build` — 4 pages in ~846 ms
- [x] `grep` confirms no remaining `rounded-2xl` / `rounded-xl` in `src/**/*.astro` (except intentional `rounded-full` and `rounded-t-lg`)
- [ ] Manual viewport check after deploy preview to confirm tighter visual rhythm reads as intended

## Skip / revert

Cosmetic. Safe to revert independently if the tighter look isn't right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)