### PR TITLE
feat(design-system): PR 3 — NetworkPulse homepage block

### DIFF
--- a/src/components/NetworkPulse.astro
+++ b/src/components/NetworkPulse.astro
@@ -1,0 +1,121 @@
+---
+import { ArrowRight } from '@lucide/astro';
+import InfoCard from './InfoCard.astro';
+import PulsingDot from './PulsingDot.astro';
+import {
+  NETWORK_STATS,
+  NETWORK_ACTIVITY,
+  statusColor,
+} from '../data/networkStatus';
+---
+
+<section
+  class="relative px-4 py-16 bg-black border-t border-white/10 overflow-hidden"
+>
+  <div class="max-w-6xl mx-auto">
+    {/* Section header */}
+    <div
+      class="flex items-end justify-between flex-wrap gap-4 mb-8"
+    >
+      <div>
+        <div class="inline-flex items-center gap-2 mb-3">
+          <PulsingDot />
+          <span
+            class="font-mono text-[13px] text-white/60 tracking-[0.02em]"
+          >
+            LIVE · refreshed 30s ago
+          </span>
+        </div>
+        <h2
+          class="text-[clamp(28px,4vw,40px)] text-white tracking-tight leading-[1.1] mb-2"
+        >
+          The mesh, right now.
+        </h2>
+        <p class="text-white/70 text-base leading-relaxed max-w-[480px]">
+          Not a marketing screenshot. The actual state of the KC backbone, updated every 30
+          seconds.
+        </p>
+      </div>
+      <a
+        href="/status"
+        class="inline-flex items-center gap-1.5 text-sm text-white/70 hover:text-white transition-colors"
+      >
+        Full network status
+        <ArrowRight class="w-3.5 h-3.5" />
+      </a>
+    </div>
+
+    {/* 3 stat tiles */}
+    <div
+      class="grid gap-3 mb-6"
+      style="grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));"
+    >
+      {
+        NETWORK_STATS.map((s) => (
+          <InfoCard>
+            <div class="text-white/50 text-[11px] uppercase tracking-[0.08em] mb-2 font-medium">
+              {s.label}
+            </div>
+            <div class="flex items-baseline gap-2.5">
+              <span
+                class="font-mono text-[48px] font-semibold leading-none tracking-[-0.03em]"
+                style={`color: ${s.color};`}
+              >
+                {s.value}
+              </span>
+              <span class="font-mono text-[13px] text-white/50">{s.unit}</span>
+            </div>
+          </InfoCard>
+        ))
+      }
+    </div>
+
+    {/* Activity strip */}
+    <div
+      class="bg-[var(--neutral-900)] border border-white/10 rounded-md overflow-hidden"
+    >
+      <div
+        class="flex items-center justify-between px-4 py-2.5 bg-white/[0.03] border-b border-white/5 text-white/50 text-[11px] uppercase tracking-[0.08em] font-medium"
+      >
+        <span>Recent activity</span>
+        <span class="font-mono normal-case tracking-normal">backbone + outliers</span>
+      </div>
+
+      <div
+        class="grid"
+        style="grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));"
+      >
+        {
+          NETWORK_ACTIVITY.map((row, i) => {
+            const color = statusColor[row.status];
+            const ringShadow =
+              row.status === 'up' ? `0 0 0 3px ${color}26` : 'none';
+            const borderTop = i >= 3 ? '1px solid rgba(255,255,255,0.05)' : 'none';
+            const borderRight =
+              i % 3 !== 2 ? '1px solid rgba(255,255,255,0.05)' : 'none';
+            return (
+              <div
+                class="flex items-center gap-3 px-4 py-3.5"
+                style={`border-top: ${borderTop}; border-right: ${borderRight};`}
+              >
+                <span
+                  class="inline-block w-2 h-2 rounded-full flex-shrink-0"
+                  style={`background: ${color}; box-shadow: ${ringShadow};`}
+                />
+                <span class="flex-1 text-white font-mono text-sm font-medium tracking-[0.01em]">
+                  {row.node}
+                </span>
+                <span class="text-white/[0.55] text-[13px] flex-1 min-w-0">
+                  {row.area}
+                </span>
+                <span class="text-white/50 font-mono text-xs min-w-[64px] text-right">
+                  {row.when}
+                </span>
+              </div>
+            );
+          })
+        }
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/data/networkStatus.ts
+++ b/src/data/networkStatus.ts
@@ -1,0 +1,35 @@
+export interface NetworkStat {
+  label: string;
+  value: string;
+  unit: string;
+  /** CSS color value (var(...) or hex). */
+  color: string;
+}
+
+export interface ActivityRow {
+  node: string;
+  area: string;
+  when: string;
+  status: 'up' | 'degraded' | 'down';
+}
+
+export const NETWORK_STATS: NetworkStat[] = [
+  { label: 'Nodes online', value: '61', unit: '↑ 3 / wk', color: 'var(--success-500)' },
+  { label: 'Routers up', value: '4', unit: '/ 6', color: 'var(--warning-500)' },
+  { label: 'Msgs · 24 h', value: '1,247', unit: 'Long Fast', color: '#fff' },
+];
+
+export const NETWORK_ACTIVITY: ActivityRow[] = [
+  { node: 'KCML', area: 'Downtown', when: 'just now', status: 'up' },
+  { node: 'WESTKC-01', area: 'Westport', when: '2m', status: 'up' },
+  { node: 'OPK-ROOF', area: 'Overland Park', when: '4m', status: 'up' },
+  { node: 'BLUSPRG-1', area: 'Blue Springs', when: '47m', status: 'degraded' },
+  { node: 'LAWR-OUT', area: 'Lawrence, KS', when: '12m', status: 'up' },
+  { node: 'INDEP-FX', area: 'Independence', when: '2d', status: 'down' },
+];
+
+export const statusColor: Record<ActivityRow['status'], string> = {
+  up: 'var(--success-500)',
+  degraded: 'var(--warning-500)',
+  down: 'var(--danger-500)',
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 import Nav from '../components/Nav.astro';
 import HeroSection from '../components/HeroSection.astro';
+import NetworkPulse from '../components/NetworkPulse.astro';
 import HardwareSection from '../components/HardwareSection.astro';
 import ResourcesSection from '../components/ResourcesSection.astro';
 import HostInfrastructureCTA from '../components/HostInfrastructureCTA.astro';
@@ -18,6 +19,7 @@ import Footer from '../components/Footer.astro';
   <div class="min-h-screen">
     <Nav currentPage="home" />
     <HeroSection />
+    <NetworkPulse />
     <HardwareSection />
     <ResourcesSection />
     <HostInfrastructureCTA />


### PR DESCRIPTION
## Summary

PR 3 of the staged design system migration in `KC Mesh Design System/MIGRATION.md`. Adds the condensed live-status block to the homepage. Reads as proof, not marketing.

Stacked on #21 (PR 2) which is stacked on #20 (PR 1).

## What changed

- **`src/components/NetworkPulse.astro`** — Astro port of the React reference in `KC Mesh Design System/ui_kits/website/NetworkPulse.jsx`.
  - Section header with `PulsingDot` + "LIVE · refreshed 30s ago" in Inconsolata
  - Three stat tiles (nodes online / routers up / 24h msgs) — Inconsolata, with the sage/amber/white colors from the design source
  - 6-cell recent-activity grid with callsigns, areas, status dots, timestamps; the "up" status dots get a muted ring shadow
- **`src/data/networkStatus.ts`** — typed `NetworkStat[]` + `ActivityRow[]` sources, hard-coded for PR 3 (MeshMonitor wiring is a separate, later concern; visual composition first)
- **`src/pages/index.astro`** — renders `<NetworkPulse />` between `<HeroSection />` and `<HardwareSection />`

## Translation notes

- `onNavigate('status')` button → plain `<a href=\"/status\">` (Astro file-based routing replaces the React routing table)
- `Icon name=\"arrow\"` → `@lucide/astro` `ArrowRight`
- JSX inline styles translated to Tailwind classes where utilities exist; per-row conditional borders and the box-shadow ring on \"up\" status dots remain inline because they're per-iteration computed values

## Known issue (resolved by PR 4)

The \"Full network status\" link points at `/status`, which doesn't exist until PR 4. Acceptable per MIGRATION.md's sequential rollout — the four PRs ship in order.

## Test plan

- [x] `npm run check` — 0 errors / 0 warnings / 43 files
- [x] `npm run build` — 4 pages in ~847 ms
- [ ] Manual: confirm NetworkPulse renders between Hero and Hardware on `/`
- [ ] Manual: confirm Inconsolata is visible on stat values, callsigns, timestamps
- [ ] Manual: confirm activity grid reflows from 3 → 2 → 1 column on tablet → mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)