### PR TITLE
feat(design-system): PR 4 — hardware, faq, status, log page templates

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -30,6 +30,18 @@ const yearRange = currentYear > startYear ? `${startYear}–${currentYear}` : `$
       <a href="/host-a-node" class="text-white/70 hover:text-white transition-colors text-sm">
         Host a Node
       </a>
+      <a href="/hardware" class="text-white/70 hover:text-white transition-colors text-sm">
+        Hardware
+      </a>
+      <a href="/faq" class="text-white/70 hover:text-white transition-colors text-sm">
+        FAQ
+      </a>
+      <a href="/status" class="text-white/70 hover:text-white transition-colors text-sm">
+        Network status
+      </a>
+      <a href="/log" class="text-white/70 hover:text-white transition-colors text-sm">
+        Field log
+      </a>
       <a
         href="/steal-this-network"
         class="text-white/70 hover:text-white transition-colors text-sm"

--- a/src/data/hardware.ts
+++ b/src/data/hardware.ts
@@ -4,6 +4,16 @@ import lilygoTDeck from '../assets/lilygo-t-deck.png';
 import rakMini from '../assets/rak-mini.png';
 import t1000e from '../assets/t1000e.png';
 
+export interface HardwareSpec {
+  label: string;
+  value: string;
+}
+
+export interface HardwareHighlight {
+  title: string;
+  body: string;
+}
+
 export interface HardwareItem {
   /** Stable key. */
   id: string;
@@ -23,6 +33,14 @@ export interface HardwareItem {
   detailDescription: string;
   /** Product image for the showcase grid. */
   image: ImageMetadata;
+  /** Optional "where to buy" link for the detail page. */
+  buyUrl?: string;
+  /** Specs grid for the detail page; omitted devices fall back to a TODO note. */
+  specs?: HardwareSpec[];
+  /** "What we like about it" highlights for the detail page. */
+  whatWeLike?: HardwareHighlight[];
+  /** "Known caveats" note for the detail-page TipBanner. */
+  caveats?: string;
 }
 
 /**
@@ -41,6 +59,33 @@ export const hardware: HardwareItem[] = [
     detailDescription:
       'Most popular starter unit. Small screen, built-in LoRa antenna. Works with your phone via Bluetooth. Perfect for testing coverage while you drive around.',
     image: heltecV4,
+    buyUrl: 'https://heltec.org',
+    specs: [
+      { label: 'LoRa chip', value: 'SX1262' },
+      { label: 'Frequency', value: '915 MHz (US)' },
+      { label: 'Transmit power', value: 'up to 22 dBm' },
+      { label: 'Antenna', value: 'SMA, included' },
+      { label: 'Battery', value: 'JST 2-pin' },
+      { label: 'Display', value: '0.96" OLED' },
+      { label: 'Connectivity', value: 'BLE + Wi-Fi' },
+      { label: 'USB', value: 'Type-C' },
+    ],
+    whatWeLike: [
+      {
+        title: 'Cheap enough to lose',
+        body: "$40 means you'll actually take it places. Drop it in a backpack, mount it on a fence, lend one to a friend without flinching.",
+      },
+      {
+        title: 'The screen earns its keep',
+        body: "Built-in OLED shows signal, battery, and recent messages without needing a phone. Useful when you're field-testing coverage.",
+      },
+      {
+        title: 'The community runs them',
+        body: 'About half of the active KC nodes are Heltecs. If you have a question, somebody in the Discord has the same hardware in front of them right now.',
+      },
+    ],
+    caveats:
+      "The Heltec's stock antenna is functional but quiet. A $15 swap to a proper 915 MHz whip will roughly double your usable range. Worth it the moment you commit to keeping the node powered up.",
   },
   {
     id: 'rak-wisblock',

--- a/src/data/networkStatus.ts
+++ b/src/data/networkStatus.ts
@@ -33,3 +33,37 @@ export const statusColor: Record<ActivityRow['status'], string> = {
   degraded: 'var(--warning-500)',
   down: 'var(--danger-500)',
 };
+
+export interface StatusStat {
+  label: string;
+  value: string;
+  delta: string;
+  color: string;
+}
+
+export interface NodeRow {
+  name: string;
+  area: string;
+  status: ActivityRow['status'];
+  lastSeen: string;
+  type: 'router' | 'client';
+  hops: number | '—';
+}
+
+export const STATUS_STATS: StatusStat[] = [
+  { label: 'Active nodes', value: '61', delta: '+3 this week', color: 'var(--success-500)' },
+  { label: 'Registered', value: '134', delta: '+8 this week', color: 'var(--info-500)' },
+  { label: 'Routers up', value: '4 / 6', delta: 'Independence down', color: 'var(--warning-500)' },
+  { label: 'Messages / 24h', value: '1,247', delta: 'Long Fast channel', color: '#fff' },
+];
+
+export const STATUS_NODES: NodeRow[] = [
+  { name: 'KCML', area: 'Downtown / KCMO', status: 'up', lastSeen: 'just now', type: 'router', hops: 0 },
+  { name: 'WESTKC-01', area: 'Westport', status: 'up', lastSeen: '2m ago', type: 'router', hops: 1 },
+  { name: 'OPK-ROOF', area: 'Overland Park', status: 'up', lastSeen: '4m ago', type: 'router', hops: 1 },
+  { name: 'BLUSPRG-1', area: 'Blue Springs', status: 'degraded', lastSeen: '47m ago', type: 'client', hops: 3 },
+  { name: 'INDEP-FX', area: 'Independence', status: 'down', lastSeen: '2d ago', type: 'router', hops: '—' },
+  { name: 'LAWR-OUT', area: 'Lawrence, KS', status: 'up', lastSeen: '12m ago', type: 'client', hops: 4 },
+  { name: 'TPKA-EDGE', area: 'Topeka, KS', status: 'up', lastSeen: '1h ago', type: 'client', hops: 5 },
+  { name: 'COL-FRINGE', area: 'Columbia, MO', status: 'down', lastSeen: '5d ago', type: 'client', hops: '—' },
+];

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -1,0 +1,102 @@
+---
+import { ChevronLeft, ChevronDown } from '@lucide/astro';
+import Layout from '../layouts/Layout.astro';
+import Nav from '../components/Nav.astro';
+import Footer from '../components/Footer.astro';
+import DiscordButton from '../components/DiscordButton.astro';
+import { DISCORD_INVITE } from '../constants/discord';
+
+const faqs = [
+  {
+    q: 'Do I need a ham license to use Meshtastic?',
+    a: "No. Meshtastic uses the unlicensed 915 MHz ISM band in the US. Anyone can put a node on the air. Hams can use it just like anyone else — but the license isn't required.",
+  },
+  {
+    q: 'Will I be able to text my friends across town on day one?',
+    a: 'Probably not directly, but probably yes via the mesh. Your node will reach the closest router or repeater, hop through any nodes in between, and reach the recipient. Coverage gets better every month as more people put nodes up.',
+  },
+  {
+    q: 'How private are messages?',
+    a: 'Direct messages are encrypted between sender and recipient. Channel messages (Primary, etc.) are encrypted to anyone with the channel key — which on the default Long Fast channel is everyone. Treat channel messages like Twitter, not like Signal.',
+  },
+  {
+    q: 'What if my node falls off the network?',
+    a: "Somebody in the Discord usually notices within an hour, and we'll ping you. Common fixes: power cycle, re-flash firmware, check the antenna seating. Nothing requires soldering.",
+  },
+  {
+    q: "Can I host a node if I don't live in KC?",
+    a: "Yes — see the Host a Node page. We're especially interested in the I-70 corridor (Lawrence, Topeka, Columbia, Manhattan) where a single host closes a chain to an existing outlier node. Email us.",
+  },
+  {
+    q: 'Is this affiliated with meshtastic.org?',
+    a: 'No. We use their open-source firmware and we love them, but KC Mesh is a local community thing. They focus on the protocol; we focus on getting actual nodes up in the metro.',
+  },
+  {
+    q: "What's the catch?",
+    a: "No catch. The site's under CC-BY-SA, the Discord is free, the hardware costs $25–$200, and the community is happy to help. The thing that stops most people is buying a node and never powering it up. Don't be that person.",
+  },
+];
+---
+
+<Layout
+  title="FAQ — Kansas City Meshtastic"
+  description="The questions we actually get in Discord, answered. Licensing, privacy, hosting, hardware."
+  path="/faq"
+>
+  <div class="min-h-screen bg-[var(--neutral-950)]">
+    <Nav currentPage="get-started" />
+
+    <div
+      class="px-4 py-12 mt-16 border-b border-white/10 bg-gradient-to-b from-[var(--neutral-900)] to-[var(--neutral-950)]"
+    >
+      <div class="max-w-3xl mx-auto">
+        <a
+          href="/"
+          class="flex items-center gap-2 text-white/70 hover:text-white transition-colors mb-8 text-sm w-fit"
+        >
+          <ChevronLeft class="w-4 h-4" />
+          Back to home
+        </a>
+        <h1 class="text-5xl md:text-6xl mb-6 tracking-tight text-white">
+          Frequently asked
+        </h1>
+        <p class="text-xl text-white/70 leading-relaxed">
+          The questions we get most often. If yours isn't here, ask in Discord — the answer
+          might end up here.
+        </p>
+      </div>
+    </div>
+
+    <article class="px-4 py-16 max-w-3xl mx-auto">
+      <div class="flex flex-col gap-3">
+        {
+          faqs.map((f) => (
+            <details
+              class="group bg-[var(--neutral-900)] border border-white/10 rounded-md p-6 hover:border-white/20 transition-colors open:border-white/20"
+            >
+              <summary class="flex items-center justify-between gap-4 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
+                <span class="text-lg text-white font-medium">{f.q}</span>
+                <ChevronDown
+                  class="w-5 h-5 text-[var(--success-500)] flex-shrink-0 transition-transform duration-200 group-open:rotate-180"
+                />
+              </summary>
+              <p class="text-white/70 leading-relaxed mt-4">{f.a}</p>
+            </details>
+          ))
+        }
+      </div>
+
+      <section class="mt-12 pt-8 border-t border-white/10">
+        <p class="text-white/70 leading-relaxed mb-6">
+          Still stuck? The Discord has 200+ people who've solved most of this stuff
+          already.
+        </p>
+        <DiscordButton href={DISCORD_INVITE} trackLabel="faq-cta">
+          Ask in Discord
+        </DiscordButton>
+      </section>
+    </article>
+
+    <Footer />
+  </div>
+</Layout>

--- a/src/pages/hardware/[id].astro
+++ b/src/pages/hardware/[id].astro
@@ -1,0 +1,171 @@
+---
+import { ChevronLeft, ExternalLink } from '@lucide/astro';
+import { Image } from 'astro:assets';
+import Layout from '../../layouts/Layout.astro';
+import Nav from '../../components/Nav.astro';
+import Footer from '../../components/Footer.astro';
+import InfoCard from '../../components/InfoCard.astro';
+import TipBanner from '../../components/TipBanner.astro';
+import PrimaryButton from '../../components/PrimaryButton.astro';
+import SecondaryButton from '../../components/SecondaryButton.astro';
+import { hardware } from '../../data/hardware';
+
+export async function getStaticPaths() {
+  return hardware.map((device) => ({
+    params: { id: device.id },
+    props: { device },
+  }));
+}
+
+const { device } = Astro.props;
+---
+
+<Layout
+  title={`${device.name} — Kansas City Meshtastic`}
+  description={device.detailDescription}
+  path={`/hardware/${device.id}`}
+>
+  <div class="min-h-screen bg-[var(--neutral-950)]">
+    <Nav currentPage="get-started" />
+
+    {/* Hero */}
+    <div
+      class="relative overflow-hidden px-4 py-16 mt-16 border-b border-white/10"
+      style="background: linear-gradient(180deg, var(--primary-800) 0%, var(--neutral-950) 90%, #000 100%);"
+    >
+      <div class="absolute inset-0 -z-10">
+        <div
+          class="absolute top-0 right-1/4 w-96 h-96 rounded-full blur-3xl"
+          style="background-color: var(--info-600); opacity: 0.25;"
+        >
+        </div>
+      </div>
+
+      <div class="max-w-6xl mx-auto">
+        <a
+          href="/hardware"
+          class="flex items-center gap-2 text-white/70 hover:text-white transition-colors mb-8 text-sm w-fit"
+        >
+          <ChevronLeft class="w-4 h-4" />
+          All hardware
+        </a>
+
+        <div class="grid lg:grid-cols-2 gap-12 items-center">
+          {/* Image */}
+          <div
+            class="aspect-[4/3] bg-white/5 backdrop-blur-xl border border-white/10 rounded-lg overflow-hidden p-8 flex items-center justify-center"
+          >
+            <Image
+              src={device.image}
+              alt={device.name}
+              class="w-full h-full object-contain"
+            />
+          </div>
+
+          {/* Meta */}
+          <div>
+            <div
+              class={`inline-block px-3 py-1 bg-gradient-to-r ${device.color} text-white rounded-md text-[13px] font-medium mb-4`}
+            >
+              {device.badge}
+            </div>
+            <h1
+              class="text-[clamp(36px,5vw,56px)] mb-4 tracking-tight text-white leading-[1.05]"
+            >
+              {device.name}
+            </h1>
+            <div
+              class="font-mono text-3xl text-[var(--success-500)] font-medium mb-4"
+            >
+              {device.detailPrice}
+            </div>
+            <p class="text-lg text-white/70 leading-relaxed mb-8">
+              {device.detailDescription}
+            </p>
+            <div class="flex flex-wrap gap-3">
+              {
+                device.buyUrl && (
+                  <PrimaryButton
+                    href={device.buyUrl}
+                    external
+                    trackEvent="hardware_buy_click"
+                    trackLabel={device.id}
+                  >
+                    <span>Where to buy</span>
+                    <ExternalLink class="w-4 h-4" />
+                  </PrimaryButton>
+                )
+              }
+              <SecondaryButton href="/getting-started">Flashing guide</SecondaryButton>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <article class="px-4 py-16 max-w-4xl mx-auto">
+      {
+        device.specs && device.specs.length > 0 && (
+          <section class="mb-16">
+            <h2 class="text-2xl text-white mb-6">Specs at a glance</h2>
+            <div
+              class="grid gap-3"
+              style="grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));"
+            >
+              {device.specs.map((spec) => (
+                <InfoCard>
+                  <div class="text-white/50 text-xs uppercase tracking-[0.06em] mb-1">
+                    {spec.label}
+                  </div>
+                  <div class="text-white text-base font-medium font-mono">
+                    {spec.value}
+                  </div>
+                </InfoCard>
+              ))}
+            </div>
+          </section>
+        )
+      }
+
+      {
+        device.whatWeLike && device.whatWeLike.length > 0 && (
+          <section class="mb-16">
+            <h2 class="text-2xl text-white mb-6">What we like about it</h2>
+            <div class="flex flex-col gap-4">
+              {device.whatWeLike.map((highlight) => (
+                <InfoCard>
+                  <h3 class="text-white mb-2">{highlight.title}</h3>
+                  <p class="text-white/70 leading-relaxed">{highlight.body}</p>
+                </InfoCard>
+              ))}
+            </div>
+          </section>
+        )
+      }
+
+      {
+        device.caveats && (
+          <section class="mb-16">
+            <h2 class="text-2xl text-white mb-6">Known caveats</h2>
+            <TipBanner>{device.caveats}</TipBanner>
+          </section>
+        )
+      }
+
+      {
+        !device.specs && !device.whatWeLike && !device.caveats && (
+          <section class="mb-16">
+            <InfoCard>
+              <p class="text-white/70 leading-relaxed">
+                We haven't written the deep-dive for this one yet. Hop in the Discord —
+                someone running one will answer faster than this page ever could.
+              </p>
+            </InfoCard>
+          </section>
+        )
+      }
+    </article>
+
+    <Footer />
+  </div>
+</Layout>

--- a/src/pages/hardware/index.astro
+++ b/src/pages/hardware/index.astro
@@ -1,0 +1,81 @@
+---
+import { ChevronLeft } from '@lucide/astro';
+import { Image } from 'astro:assets';
+import Layout from '../../layouts/Layout.astro';
+import Nav from '../../components/Nav.astro';
+import Footer from '../../components/Footer.astro';
+import FeatureCard from '../../components/FeatureCard.astro';
+import { hardware } from '../../data/hardware';
+---
+
+<Layout
+  title="Hardware — Kansas City Meshtastic"
+  description="Four Meshtastic devices the KC community actually runs. $35–$90, all field-tested."
+  path="/hardware"
+>
+  <div class="min-h-screen bg-[var(--neutral-950)]">
+    <Nav currentPage="get-started" />
+
+    <div
+      class="px-4 py-12 mt-16 border-b border-white/10 bg-gradient-to-b from-[var(--neutral-900)] to-[var(--neutral-950)]"
+    >
+      <div class="max-w-6xl mx-auto">
+        <a
+          href="/getting-started"
+          class="flex items-center gap-2 text-white/70 hover:text-white transition-colors mb-8 text-sm w-fit"
+        >
+          <ChevronLeft class="w-4 h-4" />
+          Back to Getting Started
+        </a>
+        <h1 class="text-5xl md:text-6xl mb-4 tracking-tight text-white">Hardware</h1>
+        <p class="text-xl text-white/70 max-w-2xl">
+          The four devices the KC community runs most. Each one has been mounted on
+          something, dropped in a backpack, or left on a windowsill long enough to know
+          what it's good for.
+        </p>
+      </div>
+    </div>
+
+    <article class="px-4 py-16 max-w-6xl mx-auto">
+      <div class="grid sm:grid-cols-2 lg:grid-cols-2 gap-6">
+        {
+          hardware.map((item) => (
+            <FeatureCard
+              href={`/hardware/${item.id}`}
+              interactive
+              padding="default"
+              trackEvent="hardware_detail_click"
+              trackLabel={item.id}
+            >
+              <div class="flex gap-6 items-center">
+                <div class="flex-shrink-0 w-32 h-32 rounded-md bg-gradient-to-br from-neutral-800 to-neutral-900 overflow-hidden flex items-center justify-center p-3">
+                  <Image
+                    src={item.image}
+                    alt={item.name}
+                    class="w-full h-full object-contain"
+                  />
+                </div>
+                <div class="flex-1 min-w-0">
+                  <div
+                    class={`inline-block px-3 py-1 bg-gradient-to-r ${item.color} text-white rounded-md text-xs font-medium mb-2`}
+                  >
+                    {item.badge}
+                  </div>
+                  <h3 class="text-xl text-white mb-1">{item.name}</h3>
+                  <div class="font-mono text-[var(--success-500)] text-lg mb-2">
+                    {item.detailPrice}
+                  </div>
+                  <p class="text-white/70 text-[15px] leading-relaxed">
+                    {item.shortDescription}
+                  </p>
+                </div>
+              </div>
+            </FeatureCard>
+          ))
+        }
+      </div>
+    </article>
+
+    <Footer />
+  </div>
+</Layout>

--- a/src/pages/log/bonner-tower.astro
+++ b/src/pages/log/bonner-tower.astro
@@ -1,0 +1,136 @@
+---
+import { ChevronLeft, ArrowRight } from '@lucide/astro';
+import Layout from '../../layouts/Layout.astro';
+import Nav from '../../components/Nav.astro';
+import Footer from '../../components/Footer.astro';
+import TipBanner from '../../components/TipBanner.astro';
+import MessageBanner from '../../components/MessageBanner.astro';
+import PrimaryButton from '../../components/PrimaryButton.astro';
+import DiscordButton from '../../components/DiscordButton.astro';
+import { DISCORD_INVITE } from '../../constants/discord';
+---
+
+<Layout
+  title="Bonner Springs water tower — Kansas City Meshtastic field log"
+  description="Three weeks of cold emails, one tour, one weekend, and the I-70 hop chain is officially closed on the west side."
+  path="/log/bonner-tower"
+>
+  <div class="min-h-screen bg-[var(--neutral-950)]">
+    <Nav currentPage="home" />
+
+    <div
+      class="px-4 py-12 mt-16 border-b border-white/10 bg-gradient-to-b from-[var(--neutral-900)] to-[var(--neutral-950)]"
+    >
+      <div class="max-w-[720px] mx-auto">
+        <a
+          href="/log"
+          class="flex items-center gap-2 text-white/70 hover:text-white transition-colors mb-8 text-sm w-fit"
+        >
+          <ChevronLeft class="w-4 h-4" />
+          All field logs
+        </a>
+        <div class="flex items-center gap-3 mb-6 text-white/50 text-sm">
+          <span
+            class="inline-block px-2.5 py-0.5 bg-[var(--success-500)]/15 text-[var(--success-500)] rounded-sm text-xs font-medium uppercase tracking-[0.04em]"
+          >
+            Deployment
+          </span>
+          <span>May 12, 2026</span>
+          <span>·</span>
+          <span>5 min read</span>
+        </div>
+        <h1
+          class="text-[clamp(36px,5vw,52px)] mb-4 tracking-tight text-white leading-[1.1]"
+        >
+          We finally got a node onto a Bonner Springs water tower
+        </h1>
+        <p class="text-lg text-white/70 leading-relaxed">
+          Three weeks of cold emails, one tour, one weekend, and the I-70 hop chain is
+          officially closed on the west side. Here's how it went.
+        </p>
+      </div>
+    </div>
+
+    {/* Hero photo placeholder — drop the real image into public/photos/log/ */}
+    <div class="px-4 pt-6 max-w-[960px] mx-auto">
+      <div
+        class="aspect-video w-full bg-white/5 border border-white/10 rounded-lg flex items-center justify-center text-white/40 text-sm"
+      >
+        Photo coming — bonner-tower-2026-05-12.jpg
+      </div>
+    </div>
+
+    <article class="px-4 py-16 max-w-[720px] mx-auto">
+      <div
+        class="flex flex-col gap-6 text-white/75 leading-[1.7] text-[17px]"
+      >
+        <p>
+          The first cold email went out March 20. By April we had a phone call with the
+          city's utilities supervisor, a guy named Ron who used to be a ham operator and
+          immediately understood what we were asking for. Ron's exact words:{' '}
+          <em>"Yeah, that's basically nothing. Bring it over."</em>
+        </p>
+        <p>
+          We brought it over on a Saturday. Heltec V4 in a weatherproof box, 915 MHz whip,
+          12 V power tap off the tower's existing service. Total parts: $137. Total time
+          on the platform: 40 minutes, including the safety briefing.
+        </p>
+
+        <h2 class="text-2xl text-white mt-4 mb-0">What we learned</h2>
+
+        <p>
+          <strong class="text-white">The pitch matters more than the spec.</strong> Ron
+          didn't care about LoRa or hop counts. He cared that we'd done this before, that
+          the box weighed less than a brick, and that if it broke we'd come back and take
+          it down. Treat every host conversation like a favor someone is doing you,
+          because it is.
+        </p>
+
+        <TipBanner>
+          If you're approaching a municipal site cold, lead with{' '}
+          <strong>"we're a community group doing emergency comms,"</strong> not{' '}
+          <strong>"we're hobbyists building a mesh network."</strong> Both true. One opens
+          the door.
+        </TipBanner>
+
+        <p>
+          <strong class="text-white">The first ping is the best feeling in this hobby.</strong>{' '}
+          Five minutes after we powered it up, the node showed up on the map, and a hop
+          from Topeka came through that previously couldn't reach the metro. That's the
+          whole game.
+        </p>
+
+        <h2 class="text-2xl text-white mt-4 mb-0">What's next</h2>
+
+        <p>
+          With Bonner online, the I-70 west chain is closed: Topeka → Lawrence → Bonner →
+          downtown reaches in 4 hops, reliably. The east side is the next ask — we need a
+          host in Independence or Blue Springs to do the same thing on the other side of
+          the metro.
+        </p>
+
+        <MessageBanner>
+          <p class="text-white/70 leading-relaxed m-0">
+            Massive thanks to Ron, to the Bonner Springs Public Works department, and to
+            everyone in the Discord who answered hardware questions at 9 PM on a Tuesday.
+            This one really did take a community.
+          </p>
+        </MessageBanner>
+      </div>
+
+      <div
+        class="mt-16 pt-8 border-t border-white/10 flex flex-wrap gap-4"
+      >
+        <PrimaryButton href="/host-a-node">
+          <span>Got a similar spot?</span>
+          <ArrowRight class="w-4 h-4" />
+        </PrimaryButton>
+        <DiscordButton href={DISCORD_INVITE} trackLabel="log-bonner-discord">
+          Discuss in Discord
+        </DiscordButton>
+      </div>
+    </article>
+
+    <Footer />
+  </div>
+</Layout>

--- a/src/pages/log/index.astro
+++ b/src/pages/log/index.astro
@@ -1,0 +1,84 @@
+---
+import { ChevronLeft, ArrowRight } from '@lucide/astro';
+import Layout from '../../layouts/Layout.astro';
+import Nav from '../../components/Nav.astro';
+import Footer from '../../components/Footer.astro';
+import FeatureCard from '../../components/FeatureCard.astro';
+
+interface LogEntry {
+  slug: string;
+  tag: string;
+  date: string;
+  readMinutes: number;
+  title: string;
+  excerpt: string;
+}
+
+const entries: LogEntry[] = [
+  {
+    slug: 'bonner-tower',
+    tag: 'Deployment',
+    date: 'May 12, 2026',
+    readMinutes: 5,
+    title: 'We finally got a node onto a Bonner Springs water tower',
+    excerpt:
+      'Three weeks of cold emails, one tour, one weekend, and the I-70 hop chain is officially closed on the west side. Here\'s how it went.',
+  },
+];
+---
+
+<Layout
+  title="Field log — Kansas City Meshtastic"
+  description="Deployment stories, lessons learned, and what we wish we'd known. Written by the people doing the work."
+  path="/log"
+>
+  <div class="min-h-screen bg-[var(--neutral-950)]">
+    <Nav currentPage="home" />
+
+    <div
+      class="px-4 py-12 mt-16 border-b border-white/10 bg-gradient-to-b from-[var(--neutral-900)] to-[var(--neutral-950)]"
+    >
+      <div class="max-w-3xl mx-auto">
+        <a
+          href="/"
+          class="flex items-center gap-2 text-white/70 hover:text-white transition-colors mb-8 text-sm w-fit"
+        >
+          <ChevronLeft class="w-4 h-4" />
+          Back to home
+        </a>
+        <h1 class="text-5xl md:text-6xl mb-4 tracking-tight text-white">Field log</h1>
+        <p class="text-xl text-white/70 leading-relaxed">
+          Deployment stories, lessons learned, and what we wish we'd known. Written by the
+          people doing the work.
+        </p>
+      </div>
+    </div>
+
+    <article class="px-4 py-12 max-w-3xl mx-auto">
+      <div class="flex flex-col gap-4">
+        {
+          entries.map((entry) => (
+            <FeatureCard href={`/log/${entry.slug}`} interactive padding="default">
+              <div class="flex items-center gap-3 mb-3 text-white/50 text-[13px]">
+                <span class="inline-block px-2.5 py-0.5 bg-[var(--success-500)]/15 text-[var(--success-500)] rounded-sm text-xs font-medium uppercase tracking-[0.04em]">
+                  {entry.tag}
+                </span>
+                <span>{entry.date}</span>
+                <span>·</span>
+                <span>{entry.readMinutes} min read</span>
+              </div>
+              <h2 class="text-2xl text-white mb-2 leading-tight">{entry.title}</h2>
+              <p class="text-white/70 leading-relaxed mb-4">{entry.excerpt}</p>
+              <div class="flex items-center text-sm text-white/50 group-hover:text-white">
+                <span>Read more</span>
+                <ArrowRight class="w-4 h-4 ml-1.5" />
+              </div>
+            </FeatureCard>
+          ))
+        }
+      </div>
+    </article>
+
+    <Footer />
+  </div>
+</Layout>

--- a/src/pages/status.astro
+++ b/src/pages/status.astro
@@ -1,0 +1,152 @@
+---
+import { ChevronLeft } from '@lucide/astro';
+import Layout from '../layouts/Layout.astro';
+import Nav from '../components/Nav.astro';
+import Footer from '../components/Footer.astro';
+import InfoCard from '../components/InfoCard.astro';
+import FeatureCard from '../components/FeatureCard.astro';
+import MessageBanner from '../components/MessageBanner.astro';
+import PulsingDot from '../components/PulsingDot.astro';
+import {
+  STATUS_STATS,
+  STATUS_NODES,
+  statusColor,
+} from '../data/networkStatus';
+---
+
+<Layout
+  title="Network status — Kansas City Meshtastic"
+  description="Live view of the KC backbone. What's up, what's down, what hopped through whom in the last 24 hours."
+  path="/status"
+>
+  <div class="min-h-screen bg-[var(--neutral-950)]">
+    <Nav currentPage="home" />
+
+    <div
+      class="px-4 py-12 mt-16 border-b border-white/10 bg-gradient-to-b from-[var(--neutral-900)] to-[var(--neutral-950)]"
+    >
+      <div class="max-w-6xl mx-auto">
+        <a
+          href="/"
+          class="flex items-center gap-2 text-white/70 hover:text-white transition-colors mb-8 text-sm w-fit"
+        >
+          <ChevronLeft class="w-4 h-4" />
+          Back to home
+        </a>
+        <div class="flex items-center gap-3 mb-4">
+          <PulsingDot />
+          <span class="text-sm text-white/70 font-mono">Refreshed 30s ago</span>
+        </div>
+        <h1 class="text-5xl md:text-6xl mb-4 tracking-tight text-white">
+          Network status
+        </h1>
+        <p class="text-xl text-white/70 leading-relaxed">
+          What's up, what's down, what hopped through whom in the last 24 hours.
+        </p>
+      </div>
+    </div>
+
+    <article class="px-4 py-12 max-w-6xl mx-auto">
+      {/* Stat grid */}
+      <div
+        class="grid gap-4 mb-12"
+        style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));"
+      >
+        {
+          STATUS_STATS.map((s) => (
+            <InfoCard>
+              <div class="text-white/50 text-xs uppercase tracking-[0.06em] mb-2">
+                {s.label}
+              </div>
+              <div
+                class="font-mono text-4xl font-semibold mb-1 tracking-[-0.02em]"
+                style={`color: ${s.color};`}
+              >
+                {s.value}
+              </div>
+              <div class="text-white/50 text-[13px]">{s.delta}</div>
+            </InfoCard>
+          ))
+        }
+      </div>
+
+      {/* Node table */}
+      <section class="mb-12">
+        <h2 class="text-2xl text-white mb-4">Backbone &amp; outliers</h2>
+        <FeatureCard padding="none" class="overflow-hidden">
+          <div class="overflow-x-auto">
+            <table class="w-full border-collapse min-w-[600px]">
+              <thead>
+                <tr class="bg-white/[0.03] text-left">
+                  {
+                    ['', 'Node', 'Area', 'Type', 'Hops', 'Last seen'].map((h) => (
+                      <th class="px-4 py-3 text-[11px] font-medium text-white/50 uppercase tracking-[0.06em] border-b border-white/5">
+                        {h}
+                      </th>
+                    ))
+                  }
+                </tr>
+              </thead>
+              <tbody>
+                {
+                  STATUS_NODES.map((n, i) => (
+                    <tr
+                      class={
+                        i < STATUS_NODES.length - 1
+                          ? 'border-b border-white/5'
+                          : ''
+                      }
+                    >
+                      <td class="px-4 py-3.5 w-6">
+                        <span
+                          class="inline-block w-2 h-2 rounded-full"
+                          style={`background: ${statusColor[n.status]};`}
+                        />
+                      </td>
+                      <td class="px-4 py-3.5 text-white font-medium font-mono text-sm">
+                        {n.name}
+                      </td>
+                      <td class="px-4 py-3.5 text-white/70 text-sm">{n.area}</td>
+                      <td class="px-4 py-3.5 text-sm">
+                        <span
+                          class={`inline-block px-2 py-0.5 rounded-sm text-[11px] uppercase tracking-[0.04em] font-medium ${
+                            n.type === 'router'
+                              ? 'bg-[var(--success-500)]/15 text-[var(--success-500)]'
+                              : 'bg-[var(--info-500)]/15 text-[var(--info-500)]'
+                          }`}
+                        >
+                          {n.type}
+                        </span>
+                      </td>
+                      <td class="px-4 py-3.5 text-white/70 text-sm font-mono">
+                        {n.hops}
+                      </td>
+                      <td class="px-4 py-3.5 text-white/70 text-sm">{n.lastSeen}</td>
+                    </tr>
+                  ))
+                }
+              </tbody>
+            </table>
+          </div>
+        </FeatureCard>
+      </section>
+
+      <section>
+        <h2 class="text-2xl text-white mb-4">Right now</h2>
+        <MessageBanner>
+          <p class="text-white/70 leading-relaxed mb-4">
+            <strong class="text-white">Independence (INDEP-FX)</strong> dropped off the
+            mesh two days ago — we're coordinating with the host to power-cycle. If you're
+            east of I-435 and noticed your hop count climbing, that's why.
+          </p>
+          <p class="text-white/70 leading-relaxed mb-0">
+            <strong class="text-white">COL-FRINGE</strong> has been quiet for a week.
+            Probably a power issue — investigating.
+          </p>
+        </MessageBanner>
+      </section>
+    </article>
+
+    <Footer />
+  </div>
+</Layout>


### PR DESCRIPTION
## Summary

PR 4 of the staged design system migration in `KC Mesh Design System/MIGRATION.md`. Adds the four new page surfaces.

Stacked on #22 (PR 3) which is stacked on #21 (PR 2) which is stacked on #20 (PR 1).

## New routes

| Route | Page |
|---|---|
| `/hardware` | Index of the four community-favorite devices |
| `/hardware/[id]` | Single-device deep dive — Heltec, RAK, T1000-E, Lilygo |
| `/faq` | Common questions, native `<details>` accordion |
| `/status` | Live dashboard — stat grid + node table + "right now" |
| `/log` | Field-log index |
| `/log/bonner-tower` | First entry — water tower deployment |

Each page uses the established visual vocabulary: subpage header (gradient + back link) → article body → Footer. InfoCard / FeatureCard / TipBanner / MessageBanner as building blocks.

## Translation notes from MIGRATION.md

- **React `useState` accordion → native `<details><summary>`.** Zero JS, same UX, accessible by default. `ChevronDown` rotates via CSS `group-open:rotate-180`.
- **React routing table → Astro file-based routing.** `/hardware/[id]` uses `getStaticPaths` to emit one HTML per device at build time.
- **`<image-slot>` web component → simple bordered placeholder div.** Per MIGRATION.md PR 5's recommendation: real photos go in `public/photos/log/` when authored, not a localStorage-backed slot that won't sync between visitors.

## Data changes

- **`src/data/hardware.ts`** — `HardwareItem` gains optional `specs`, `whatWeLike`, `caveats`, `buyUrl` fields. Heltec V4 populated from the design source; the other three render a "haven't written this yet" InfoCard on the detail page until their content lands. (No invented spec data.)
- **`src/data/networkStatus.ts`** — adds `STATUS_STATS` (4 tiles), `STATUS_NODES` (8 nodes including the I-70 corridor outliers), `NodeRow` type.

## Footer

Added FAQ, Hardware, Network status, Field log links. Order preserves the utility-first → external/social-last convention.

## Primary nav

**Untouched.** MIGRATION.md recommends adding `/status` to the primary nav; deferred to a follow-up so this PR doesn't change navigation shape. `/status` is reachable from the homepage NetworkPulse "Full network status" link (PR 3) and the footer.

## Test plan

- [x] `npm run check` — 0 errors / 0 warnings / 49 files
- [x] `npm run build` — 13 pages in ~907 ms (was 4; +4 templates + 4 hardware detail + log/index + log/bonner-tower minus one for not double-counting log)
- [ ] Manual: `/hardware/heltec-v3-v4` shows full specs / what-we-like / caveats
- [ ] Manual: the other three hardware detail pages show the graceful-degradation copy
- [ ] Manual: `/faq` accordion expands and collapses; only one open at a time is **not** enforced (this is `<details>` default — multiple can be open; matches "more like a collapsible cheat sheet than a quiz" UX)
- [ ] Manual: `/status` table reflows on narrow viewports (the FeatureCard wraps `overflow-x-auto`)
- [ ] Manual: `/log/bonner-tower` hero placeholder reads as "TODO photo" not "broken"

🤖 Generated with [Claude Code](https://claude.com/claude-code)