### PR TITLE
feat: live mesh + Discord stats hydrate from /api/stats.json

### DIFF
--- a/src/components/FinalCTASection.astro
+++ b/src/components/FinalCTASection.astro
@@ -43,7 +43,7 @@ import { Radio } from '@lucide/astro';
 
     <p class="text-xl text-white/70 leading-relaxed mb-8 max-w-2xl mx-auto">
       Whether you're saying hello on the mesh or asking questions in Discord — pick up a node, check
-      the coverage map, find the channel where you fit.
+      the coverage map, make a contact.
     </p>
   </div>
 </section>

--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -57,7 +57,14 @@ import { DISCORD_INVITE } from '../constants/discord';
           </div>
           <div>
             <h3 class="text-lg mb-1 text-white">
-              60+ active nodes. 130+ total nodes. 200+ in Discord.
+              <span class="font-mono" data-live-stat="active_30d">—</span> nodes active this month.{
+                ' '
+              }
+              <span class="font-mono" data-live-stat="total_nodes">—</span> registered ever.{' '}
+              <span class="font-mono" data-live-stat="discord_total_members">—</span> in Discord (<span
+                class="font-mono"
+                data-live-stat="discord_online">—</span
+              > online now).
             </h3>
             <p class="text-white/70 leading-relaxed">
               Power up a Meshtastic node and say hello. Someone in the mesh will hear you.

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -30,18 +30,22 @@ const linkClass = (active: boolean) => (active ? 'text-white' : 'text-white/70 h
 >
   <div class="max-w-6xl mx-auto px-4 py-4">
     <div class="flex items-center justify-between gap-4">
-      {/* Left: Brand/Status */}
-      <div class="flex items-center gap-2 md:gap-3">
-        <img src={logo.src} alt="KC Mesh" class="w-8 h-8 rounded-sm" />
+      {/* Left: Brand/Status — links to home from every page. */}
+      <a
+        href="/"
+        aria-label="Kansas City Meshtastic Network — home"
+        class="flex items-center gap-2 md:gap-3 group"
+      >
+        <img src={logo.src} alt="" class="w-8 h-8 rounded-sm" />
         <div
-          class="flex items-center gap-2 px-3 py-1.5 bg-white/10 backdrop-blur-xs rounded-full border border-white/20"
+          class="flex items-center gap-2 px-3 py-1.5 bg-white/10 backdrop-blur-xs rounded-full border border-white/20 group-hover:bg-white/15 group-hover:border-white/30 transition-colors"
         >
           <span class="flex items-center">
             <PulsingDot />
           </span>
           <span class="text-sm text-white font-medium hidden sm:inline">KC Mesh</span>
         </div>
-      </div>
+      </a>
 
       {/* Right: Navigation */}
       <div class="flex items-center gap-3 md:gap-6">

--- a/src/components/NetworkPulse.astro
+++ b/src/components/NetworkPulse.astro
@@ -2,7 +2,7 @@
 import { ArrowRight } from '@lucide/astro';
 import InfoCard from './InfoCard.astro';
 import PulsingDot from './PulsingDot.astro';
-import { NETWORK_STATS, NETWORK_ACTIVITY, statusColor } from '../data/networkStatus';
+import { NETWORK_ACTIVITY, statusColor } from '../data/networkStatus';
 ---
 
 <section class="relative px-4 py-16 bg-black border-t border-white/10 overflow-hidden">
@@ -13,14 +13,14 @@ import { NETWORK_STATS, NETWORK_ACTIVITY, statusColor } from '../data/networkSta
         <div class="inline-flex items-center gap-2 mb-3">
           <PulsingDot />
           <span class="font-mono text-[13px] text-white/60 tracking-[0.02em]">
-            LIVE · refreshed 30s ago
+            LIVE · updated <span data-live-stat="generated_at_relative">just now</span>
           </span>
         </div>
         <h2 class="text-[clamp(28px,4vw,40px)] text-white tracking-tight leading-[1.1] mb-2">
           The mesh, right now.
         </h2>
         <p class="text-white/70 text-base leading-relaxed max-w-[480px]">
-          Not a marketing screenshot. The actual state of the KC backbone, updated every 30 seconds.
+          Not a marketing screenshot. Live counts from the KC MeshMonitor instance.
         </p>
       </div>
       <a
@@ -37,24 +37,50 @@ import { NETWORK_STATS, NETWORK_ACTIVITY, statusColor } from '../data/networkSta
       class="grid gap-3 mb-6"
       style="grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));"
     >
-      {
-        NETWORK_STATS.map((s) => (
-          <InfoCard>
-            <div class="text-white/50 text-[11px] uppercase tracking-[0.08em] mb-2 font-medium">
-              {s.label}
-            </div>
-            <div class="flex items-baseline gap-2.5">
-              <span
-                class="font-mono text-[48px] font-semibold leading-none tracking-[-0.03em]"
-                style={`color: ${s.color};`}
-              >
-                {s.value}
-              </span>
-              <span class="font-mono text-[13px] text-white/50">{s.unit}</span>
-            </div>
-          </InfoCard>
-        ))
-      }
+      <InfoCard>
+        <div class="text-white/50 text-[11px] uppercase tracking-[0.08em] mb-2 font-medium">
+          Active · 30 days
+        </div>
+        <div class="flex items-baseline gap-2.5">
+          <span
+            class="font-mono text-[48px] font-semibold leading-none tracking-[-0.03em] text-(--success-500)"
+            data-live-stat="active_30d"
+          >
+            —
+          </span>
+          <span class="font-mono text-[13px] text-white/50">nodes</span>
+        </div>
+      </InfoCard>
+
+      <InfoCard>
+        <div class="text-white/50 text-[11px] uppercase tracking-[0.08em] mb-2 font-medium">
+          Total registered
+        </div>
+        <div class="flex items-baseline gap-2.5">
+          <span
+            class="font-mono text-[48px] font-semibold leading-none tracking-[-0.03em] text-(--info-500)"
+            data-live-stat="total_nodes"
+          >
+            —
+          </span>
+          <span class="font-mono text-[13px] text-white/50">ever</span>
+        </div>
+      </InfoCard>
+
+      <InfoCard>
+        <div class="text-white/50 text-[11px] uppercase tracking-[0.08em] mb-2 font-medium">
+          Messages tracked
+        </div>
+        <div class="flex items-baseline gap-2.5">
+          <span
+            class="font-mono text-[48px] font-semibold leading-none tracking-[-0.03em] text-white"
+            data-live-stat="message_count"
+          >
+            —
+          </span>
+          <span class="font-mono text-[13px] text-white/50">Long Fast</span>
+        </div>
+      </InfoCard>
     </div>
 
     {/* Activity strip */}
@@ -62,8 +88,8 @@ import { NETWORK_STATS, NETWORK_ACTIVITY, statusColor } from '../data/networkSta
       <div
         class="flex items-center justify-between px-4 py-2.5 bg-white/3 border-b border-white/5 text-white/50 text-[11px] uppercase tracking-[0.08em] font-medium"
       >
-        <span>Recent activity</span>
-        <span class="font-mono normal-case tracking-normal">backbone + outliers</span>
+        <span>Recent activity · sample</span>
+        <span class="font-mono normal-case tracking-normal">per-node feed coming soon</span>
       </div>
 
       <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));">

--- a/src/constants/discord.ts
+++ b/src/constants/discord.ts
@@ -1,1 +1,12 @@
 export const DISCORD_INVITE = 'https://discord.gg/yr2QTFSvzN';
+
+/**
+ * Discord server snowflake ID. Kept here for reference; not used at runtime.
+ * The server-side cron at /home/admin/generate-mesh-stats.py queries the
+ * Discord guild API with this ID and bakes member/online counts into
+ * /api/stats.json, which the site fetches.
+ *
+ * If you fork this for your city: change this ID, change DISCORD_INVITE
+ * above, and update the cron script's DISCORD_GUILD_ID to match.
+ */
+export const DISCORD_GUILD_ID = '1424474686619783191';

--- a/src/data/networkStatus.ts
+++ b/src/data/networkStatus.ts
@@ -1,23 +1,9 @@
-export interface NetworkStat {
-  label: string;
-  value: string;
-  unit: string;
-  /** CSS color value (var(...) or hex). */
-  color: string;
-}
-
 export interface ActivityRow {
   node: string;
   area: string;
   when: string;
   status: 'up' | 'degraded' | 'down';
 }
-
-export const NETWORK_STATS: NetworkStat[] = [
-  { label: 'Nodes online', value: '61', unit: '↑ 3 / wk', color: 'var(--success-500)' },
-  { label: 'Routers up', value: '4', unit: '/ 6', color: 'var(--warning-500)' },
-  { label: 'Msgs · 24 h', value: '1,247', unit: 'Long Fast', color: '#fff' },
-];
 
 export const NETWORK_ACTIVITY: ActivityRow[] = [
   { node: 'KCML', area: 'Downtown', when: 'just now', status: 'up' },
@@ -34,13 +20,6 @@ export const statusColor: Record<ActivityRow['status'], string> = {
   down: 'var(--danger-500)',
 };
 
-export interface StatusStat {
-  label: string;
-  value: string;
-  delta: string;
-  color: string;
-}
-
 export interface NodeRow {
   name: string;
   area: string;
@@ -49,13 +28,6 @@ export interface NodeRow {
   type: 'router' | 'client';
   hops: number | '—';
 }
-
-export const STATUS_STATS: StatusStat[] = [
-  { label: 'Active nodes', value: '61', delta: '+3 this week', color: 'var(--success-500)' },
-  { label: 'Registered', value: '134', delta: '+8 this week', color: 'var(--info-500)' },
-  { label: 'Routers up', value: '4 / 6', delta: 'Independence down', color: 'var(--warning-500)' },
-  { label: 'Messages / 24h', value: '1,247', delta: 'Long Fast channel', color: '#fff' },
-];
 
 export const STATUS_NODES: NodeRow[] = [
   {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -72,5 +72,11 @@ const ogImage = new URL('/og-image.png', Astro.site ?? 'https://kansascitymesh.l
         trackEvent(action, label);
       });
     </script>
+
+    {/* Hydrate live stats for elements marked with data-live-stat. */}
+    <script>
+      import { hydrateLiveStats } from '../utils/liveStats';
+      hydrateLiveStats();
+    </script>
   </body>
 </html>

--- a/src/pages/status.astro
+++ b/src/pages/status.astro
@@ -5,14 +5,14 @@ import Nav from '../components/Nav.astro';
 import Footer from '../components/Footer.astro';
 import InfoCard from '../components/InfoCard.astro';
 import FeatureCard from '../components/FeatureCard.astro';
-import MessageBanner from '../components/MessageBanner.astro';
+import TipBanner from '../components/TipBanner.astro';
 import PulsingDot from '../components/PulsingDot.astro';
-import { STATUS_STATS, STATUS_NODES, statusColor } from '../data/networkStatus';
+import { STATUS_NODES, statusColor } from '../data/networkStatus';
 ---
 
 <Layout
   title="Network status — Kansas City Meshtastic"
-  description="Live view of the KC backbone. What's up, what's down, what hopped through whom in the last 24 hours."
+  description="Live view of the KC mesh — active node counts, total registered, message volume. Pulled from the KC MeshMonitor instance."
   path="/status"
 >
   <div class="min-h-screen bg-(--neutral-950)">
@@ -31,41 +31,191 @@ import { STATUS_STATS, STATUS_NODES, statusColor } from '../data/networkStatus';
         </a>
         <div class="flex items-center gap-3 mb-4">
           <PulsingDot />
-          <span class="text-sm text-white/70 font-mono">Refreshed 30s ago</span>
+          <span class="text-sm text-white/70 font-mono">
+            Updated <span data-live-stat="generated_at_relative">just now</span>
+          </span>
         </div>
         <h1 class="text-5xl md:text-6xl mb-4 tracking-tight text-white">Network status</h1>
         <p class="text-xl text-white/70 leading-relaxed">
-          What's up, what's down, what hopped through whom in the last 24 hours.
+          Live counts from the KC MeshMonitor instance at{' '}
+          <a
+            href="https://map.kansascitymesh.live"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-white hover:text-(--info-500) underline underline-offset-4"
+          >
+            map.kansascitymesh.live
+          </a>.
         </p>
       </div>
     </div>
 
     <article class="px-4 py-12 max-w-6xl mx-auto">
-      {/* Stat grid */}
-      <div
-        class="grid gap-4 mb-12"
-        style="grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));"
-      >
-        {
-          STATUS_STATS.map((s) => (
-            <InfoCard>
-              <div class="text-white/50 text-xs uppercase tracking-[0.06em] mb-2">{s.label}</div>
-              <div
-                class="font-mono text-4xl font-semibold mb-1 tracking-[-0.02em]"
-                style={`color: ${s.color};`}
-              >
-                {s.value}
-              </div>
-              <div class="text-white/50 text-[13px]">{s.delta}</div>
-            </InfoCard>
-          ))
-        }
-      </div>
-
-      {/* Node table */}
+      {/* Activity-window stat grid */}
       <section class="mb-12">
-        <h2 class="text-2xl text-white mb-4">Backbone &amp; outliers</h2>
-        <FeatureCard padding="none" class="overflow-hidden">
+        <h2 class="text-2xl text-white mb-4">Active nodes</h2>
+        <div
+          class="grid gap-4"
+          style="grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));"
+        >
+          <InfoCard>
+            <div class="text-white/50 text-xs uppercase tracking-[0.06em] mb-2">Last hour</div>
+            <div
+              class="font-mono text-4xl font-semibold mb-1 tracking-[-0.02em] text-(--success-500)"
+              data-live-stat="active_1h"
+            >
+              —
+            </div>
+            <div class="text-white/50 text-[13px]">on the air now</div>
+          </InfoCard>
+          <InfoCard>
+            <div class="text-white/50 text-xs uppercase tracking-[0.06em] mb-2">Last 24h</div>
+            <div
+              class="font-mono text-4xl font-semibold mb-1 tracking-[-0.02em] text-(--success-500)"
+              data-live-stat="active_24h"
+            >
+              —
+            </div>
+            <div class="text-white/50 text-[13px]">heard from yesterday</div>
+          </InfoCard>
+          <InfoCard>
+            <div class="text-white/50 text-xs uppercase tracking-[0.06em] mb-2">Last 7 days</div>
+            <div
+              class="font-mono text-4xl font-semibold mb-1 tracking-[-0.02em] text-(--success-500)"
+              data-live-stat="active_7d"
+            >
+              —
+            </div>
+            <div class="text-white/50 text-[13px]">this week</div>
+          </InfoCard>
+          <InfoCard>
+            <div class="text-white/50 text-xs uppercase tracking-[0.06em] mb-2">Last 30 days</div>
+            <div
+              class="font-mono text-4xl font-semibold mb-1 tracking-[-0.02em] text-(--success-500)"
+              data-live-stat="active_30d"
+            >
+              —
+            </div>
+            <div class="text-white/50 text-[13px]">this month</div>
+          </InfoCard>
+          <InfoCard>
+            <div class="text-white/50 text-xs uppercase tracking-[0.06em] mb-2">Last 90 days</div>
+            <div
+              class="font-mono text-4xl font-semibold mb-1 tracking-[-0.02em] text-(--success-500)"
+              data-live-stat="active_90d"
+            >
+              —
+            </div>
+            <div class="text-white/50 text-[13px]">this quarter</div>
+          </InfoCard>
+        </div>
+      </section>
+
+      {/* Totals + message volume */}
+      <section class="mb-12">
+        <h2 class="text-2xl text-white mb-4">Totals</h2>
+        <div
+          class="grid gap-4"
+          style="grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));"
+        >
+          <InfoCard>
+            <div class="text-white/50 text-xs uppercase tracking-[0.06em] mb-2">
+              Nodes ever registered
+            </div>
+            <div
+              class="font-mono text-4xl font-semibold mb-1 tracking-[-0.02em] text-(--info-500)"
+              data-live-stat="total_nodes"
+            >
+              —
+            </div>
+            <div class="text-white/50 text-[13px]">since MeshMonitor started counting</div>
+          </InfoCard>
+          <InfoCard>
+            <div class="text-white/50 text-xs uppercase tracking-[0.06em] mb-2">
+              Hardware identified
+            </div>
+            <div
+              class="font-mono text-4xl font-semibold mb-1 tracking-[-0.02em] text-(--info-500)"
+              data-live-stat="nodes_with_hwmodel"
+            >
+              —
+            </div>
+            <div class="text-white/50 text-[13px]">model reported via telemetry</div>
+          </InfoCard>
+          <InfoCard>
+            <div class="text-white/50 text-xs uppercase tracking-[0.06em] mb-2">
+              Messages tracked
+            </div>
+            <div
+              class="font-mono text-4xl font-semibold mb-1 tracking-[-0.02em] text-white"
+              data-live-stat="message_count"
+            >
+              —
+            </div>
+            <div class="text-white/50 text-[13px]">Long Fast channel</div>
+          </InfoCard>
+          <InfoCard>
+            <div class="text-white/50 text-xs uppercase tracking-[0.06em] mb-2">Channels seen</div>
+            <div
+              class="font-mono text-4xl font-semibold mb-1 tracking-[-0.02em] text-white"
+              data-live-stat="channel_count"
+            >
+              —
+            </div>
+            <div class="text-white/50 text-[13px]">primary + custom</div>
+          </InfoCard>
+        </div>
+      </section>
+
+      {/* Discord */}
+      <section class="mb-12">
+        <h2 class="text-2xl text-white mb-4">Discord</h2>
+        <div
+          class="grid gap-4"
+          style="grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));"
+        >
+          <InfoCard>
+            <div class="text-white/50 text-xs uppercase tracking-[0.06em] mb-2">Total members</div>
+            <div
+              class="font-mono text-4xl font-semibold mb-1 tracking-[-0.02em] text-(--info-500)"
+              data-live-stat="discord_total_members"
+            >
+              —
+            </div>
+            <div class="text-white/50 text-[13px]">people in the server</div>
+          </InfoCard>
+          <InfoCard>
+            <div class="text-white/50 text-xs uppercase tracking-[0.06em] mb-2">Online now</div>
+            <div
+              class="font-mono text-4xl font-semibold mb-1 tracking-[-0.02em] text-(--success-500)"
+              data-live-stat="discord_online"
+            >
+              —
+            </div>
+            <div class="text-white/50 text-[13px]">presence right now</div>
+          </InfoCard>
+        </div>
+      </section>
+
+      {/* Node table — labeled as sample until we have a per-node API */}
+      <section class="mb-12">
+        <div class="flex items-center justify-between flex-wrap gap-3 mb-4">
+          <h2 class="text-2xl text-white">Backbone &amp; outliers</h2>
+          <span
+            class="inline-block px-2 py-0.5 rounded-sm text-[11px] uppercase tracking-[0.04em] font-medium bg-(--warning-500)/15 text-(--warning-500)"
+          >
+            Sample data
+          </span>
+        </div>
+        <TipBanner>
+          The aggregate counts above are live from{' '}
+          <a
+            href="/api/stats.json"
+            class="text-white underline underline-offset-4 hover:text-(--success-500)">stats.json</a
+          >. The table below is illustrative — MeshMonitor doesn't expose per-node detail on the
+          public endpoint yet. When it does, this table will go live too.
+        </TipBanner>
+        <FeatureCard padding="none" class="overflow-hidden mt-4">
           <div class="overflow-x-auto">
             <table class="w-full border-collapse min-w-[600px]">
               <thead>
@@ -111,21 +261,6 @@ import { STATUS_STATS, STATUS_NODES, statusColor } from '../data/networkStatus';
             </table>
           </div>
         </FeatureCard>
-      </section>
-
-      <section>
-        <h2 class="text-2xl text-white mb-4">Right now</h2>
-        <MessageBanner>
-          <p class="text-white/70 leading-relaxed mb-4">
-            <strong class="text-white">Independence (INDEP-FX)</strong> dropped off the mesh two days
-            ago — we're coordinating with the host to power-cycle. If you're east of I-435 and noticed
-            your hop count climbing, that's why.
-          </p>
-          <p class="text-white/70 leading-relaxed mb-0">
-            <strong class="text-white">COL-FRINGE</strong> has been quiet for a week. Probably a power
-            issue — investigating.
-          </p>
-        </MessageBanner>
       </section>
     </article>
 

--- a/src/utils/liveStats.ts
+++ b/src/utils/liveStats.ts
@@ -1,0 +1,109 @@
+/**
+ * Runtime hydration of "live" stats on the site.
+ *
+ * One source: `/api/stats.json`, generated server-side by
+ * /home/admin/generate-mesh-stats.py on a 12-hour cron. The script fetches
+ * MeshMonitor's API plus the Discord guild API and writes a unified blob.
+ *
+ * Elements opt in by adding `data-live-stat="<key>"`. The HTML carries
+ * a placeholder value (em-dash, "just now", etc.) as its text content;
+ * this script swaps it once the fetch completes. If the fetch fails, the
+ * placeholder stays — the page is still meaningful.
+ *
+ * Keys are flat, dot-free strings so they're easy to read in HTML:
+ *
+ *   data-live-stat="active_1h"
+ *   data-live-stat="active_24h"
+ *   data-live-stat="active_7d"
+ *   data-live-stat="active_30d"
+ *   data-live-stat="active_90d"
+ *   data-live-stat="total_nodes"
+ *   data-live-stat="nodes_with_hwmodel"
+ *   data-live-stat="message_count"
+ *   data-live-stat="channel_count"
+ *   data-live-stat="discord_total_members"
+ *   data-live-stat="discord_online"
+ *   data-live-stat="generated_at_relative"   (e.g. "2m ago")
+ */
+
+interface MeshtasticStats {
+  schema_version: number;
+  generated_at: string;
+  generated_at_epoch: number;
+  source: string;
+  total_nodes: number;
+  nodes_with_hwmodel: number;
+  message_count: number | null;
+  channel_count: number | null;
+  active_window_seconds: Record<'1h' | '24h' | '7d' | '30d' | '90d', number>;
+  active_counts: Record<'1h' | '24h' | '7d' | '30d' | '90d', number>;
+  top_hardware_30d: Array<{
+    hw_model: number;
+    name: string;
+    count: number;
+    percent: number;
+  }>;
+  top_hardware_all: Array<{
+    hw_model: number;
+    name: string;
+    count: number;
+    percent: number;
+  }>;
+  discord_total_members: number | null;
+  discord_online: number | null;
+}
+
+const STATS_URL = '/api/stats.json';
+
+function formatNumber(n: number | null | undefined): string | null {
+  if (n === null || n === undefined) return null;
+  return n.toLocaleString('en-US');
+}
+
+function formatRelative(isoTimestamp: string): string {
+  const then = Date.parse(isoTimestamp);
+  if (!Number.isFinite(then)) return '';
+  const seconds = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
+function replaceStat(key: string, value: string | null) {
+  if (value === null) return;
+  document.querySelectorAll<HTMLElement>(`[data-live-stat="${key}"]`).forEach((el) => {
+    el.textContent = value;
+  });
+}
+
+export function hydrateLiveStats(): void {
+  if (typeof window === 'undefined') return;
+  if (!document.querySelector('[data-live-stat]')) return;
+
+  void (async () => {
+    try {
+      const res = await fetch(STATS_URL, { cache: 'no-store' });
+      if (!res.ok) return;
+      const stats = (await res.json()) as MeshtasticStats;
+
+      replaceStat('active_1h', formatNumber(stats.active_counts['1h']));
+      replaceStat('active_24h', formatNumber(stats.active_counts['24h']));
+      replaceStat('active_7d', formatNumber(stats.active_counts['7d']));
+      replaceStat('active_30d', formatNumber(stats.active_counts['30d']));
+      replaceStat('active_90d', formatNumber(stats.active_counts['90d']));
+      replaceStat('total_nodes', formatNumber(stats.total_nodes));
+      replaceStat('nodes_with_hwmodel', formatNumber(stats.nodes_with_hwmodel));
+      replaceStat('message_count', formatNumber(stats.message_count));
+      replaceStat('channel_count', formatNumber(stats.channel_count));
+      replaceStat('discord_total_members', formatNumber(stats.discord_total_members));
+      replaceStat('discord_online', formatNumber(stats.discord_online));
+      replaceStat('generated_at_relative', formatRelative(stats.generated_at));
+    } catch {
+      // Leave placeholders in place. Page is still meaningful.
+    }
+  })();
+}


### PR DESCRIPTION
## What changes on the live site

The hardcoded brag in the hero — "60+ active nodes. 130+ total nodes. 200+ in Discord." — becomes:

> **103** nodes active this month. **719** registered ever. **188** in Discord (**28** online now).

(Real numbers as of right now. Refresh every 12h.)

The NetworkPulse block on the homepage, the `/status` page, and the Discord member counts all hydrate from a single fetch to `/api/stats.json`. Placeholder values stay if the fetch fails — page is always meaningful.

## Architecture (revisited briefly because it's elegant)

```
                   (every 12h via cron)
                   ┌──────────────────────────────────┐
                   │ /home/admin/generate-mesh-stats.py
                   │   ├─ fetch MeshMonitor /api/nodes + /api/stats
                   │   ├─ fetch Discord guild /api/v10/guilds/<id>?with_counts=true
                   │   │     (DISCORD_BOT_TOKEN from /home/admin/.env)
                   │   ├─ compute active counts, top hardware, etc.
                   │   └─ atomic write → /home/admin/kcml-stats/stats.json
                   └──────────────────────────────────┘
                                  │ bind-mount
                                  ▼
                          mesh-web nginx container
                                  │
                                  ▼
                       https://kansascitymesh.live/api/stats.json
                                  │ fetch on page load
                                  ▼
                    src/utils/liveStats.ts swaps [data-live-stat] elements
```

One fetch, one token (server-side only, never in the browser, never in GitHub Actions), one cron, atomic writes that leave the old file intact on failure.

## Why server-side cron over build-time fetch

Considered three options:

| Approach | Cadence | Token lives in | Complexity |
|---|---|---|---|
| Build-time fetch | Per deploy | GitHub Actions secret | Medium (astro.config.mjs hook + build env) |
| **Server cron (chosen)** | Every 12h | Server `.env` | Minimal (extend existing script) |
| Client-side Discord widget | Real-time | None | Low, but only `online_now`, not total members |

Server cron wins because the infrastructure already exists. The existing `generate-mesh-stats.py` was the right place to extend — it already runs every 12h, has atomic writes, leaves old data on failure, and writes to a path nginx already serves. Adding Discord is 40 lines.

The `DISCORD_BOT_TOKEN` GitHub Actions secret is now unused. Could be removed in a followup, or kept for future build-time use cases.

## Code changes

| File | What changed |
|---|---|
| `src/utils/liveStats.ts` (new) | One fetch, populates any element with `data-live-stat="<key>"`. 12 supported keys covering active windows, totals, hardware count, message/channel counts, Discord members + online, and a relative timestamp. |
| `src/layouts/Layout.astro` | Invokes `hydrateLiveStats()` on every page. No-ops if no `[data-live-stat]` elements present. |
| `src/components/HeroSection.astro` | Stat headline rewritten with `data-live-stat` spans + em-dash placeholders. |
| `src/components/NetworkPulse.astro` | Three tiles + timestamp eyebrow go live. Activity strip labeled "sample · per-node feed coming soon." |
| `src/pages/status.astro` | Three live stat grids: Active nodes (5 windows), Totals (4 numbers), Discord (2 numbers). Sample node table preserved with a "Sample data" badge + TipBanner. |
| `src/constants/discord.ts` | `DISCORD_GUILD_ID` becomes documentation-only — not imported at runtime now that everything comes from `/api/stats.json`. |
| `src/data/networkStatus.ts` | Drop dead `NETWORK_STATS` + `STATUS_STATS` exports (replaced by live data). |

## Server-side change (not in this diff)

`/home/admin/generate-mesh-stats.py` extended:
- Bumped `SCHEMA_VERSION` to 2 (new optional fields: `discord_total_members`, `discord_online`)
- New `read_env_file()` helper (cron has minimal env, so the script sources `/home/admin/.env` directly)
- New `fetch_discord_stats()` that calls `GET /api/v10/guilds/{id}?with_counts=true` with the bot token
- Graceful degradation: Discord failure logs to stderr and leaves the new fields `null`; the mesh-side fetch is unaffected

Verified end-to-end: ran the script once manually, confirmed `schema_version: 2` and the new fields appear in `https://kansascitymesh.live/api/stats.json`.

(The server script isn't checked into the repo today — a followup could move it to `deploy/server/generate-mesh-stats.py` alongside `deploy-kcmesh.sh` for source-of-truth.)

## Also in this PR — Nav home-link fix

The KC Mesh logo + status badge in the nav had no `<a>` wrapping them. Clicking either did nothing. Wrapped the whole left cluster in `<a href="/">` with `aria-label="Kansas City Meshtastic Network — home"`, marked the now-decorative img with `alt=""` (avoids screen readers announcing "KC Mesh" twice), added a subtle `group-hover` brightening on the badge so the cursor signals it's clickable. Reported inline; fixed inline since it's small and on the same surface.

## Test plan

- [x] `npm run format:check` — clean
- [x] `npm run check` — 0 errors / 0 warnings / 49 files
- [x] `npm run build` — 13 pages in ~985ms
- [x] Server: `generate-mesh-stats.py` runs cleanly, produces schema v2 with Discord fields
- [x] `curl https://kansascitymesh.live/api/stats.json | jq .schema_version` → 2
- [ ] **After merge:** deploy auto-fires; verify hero + NetworkPulse + /status display live numbers; confirm Nav logo links to /
- [ ] **After merge:** confirm the 12h cron continues to refresh discord_total_members and discord_online

## Followups

- Move `generate-mesh-stats.py` to `deploy/server/` in the repo as source-of-truth (parallel to `deploy-kcmesh.sh`)
- Decide whether to drop the unused `DISCORD_BOT_TOKEN` GitHub Actions secret
- "Top hardware in the wild" section using `top_hardware_30d` from the same endpoint (deferred from earlier conversation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)