### PR TITLE
chore(deploy): track stats generator in repo + 5-min cadence + drop unused secret

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,6 +1,6 @@
 # Deploy
 
-How `kansascitymesh.live` ships to production.
+How `kansascitymesh.live` ships to production, and how its server-side support pieces work.
 
 ## Architecture
 
@@ -31,32 +31,71 @@ Traefik → mesh-web (nginx:alpine) → /usr/share/nginx/html
 
 ## Files
 
-| File                                                    | Lives                       | Purpose                                                              |
-| ------------------------------------------------------- | --------------------------- | -------------------------------------------------------------------- |
-| `.github/workflows/deploy.yml`                          | this repo                   | Builds + ships on push to main                                       |
-| `deploy/server/deploy-kcmesh.sh`                        | this repo (source of truth) | Server-side script — atomic dist swap                                |
-| `/home/admin/deploy-kcmesh.sh`                          | droplet                     | Installed copy. Pinned as `command="…"` in `~/.ssh/authorized_keys`. |
-| `/home/admin/.rebuild-trigger/deploy-kcmesh.{log,lock}` | droplet                     | Deploy log + flock for serialization                                 |
+| File                                                    | Lives                       | Purpose                                                                                           |
+| ------------------------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------- |
+| `.github/workflows/deploy.yml`                          | this repo                   | Builds + ships on push to main                                                                    |
+| `deploy/server/deploy-kcmesh.sh`                        | this repo (source of truth) | Server-side deploy script — atomic dist swap                                                      |
+| `deploy/server/generate-mesh-stats.py`                  | this repo (source of truth) | Server-side stats generator — runs via cron, produces `/api/stats.json`                           |
+| `/home/admin/deploy-kcmesh.sh`                          | droplet                     | Installed copy. Pinned as `command="…"` in `~/.ssh/authorized_keys`.                              |
+| `/home/admin/generate-mesh-stats.py`                    | droplet                     | Installed copy. Run by cron every 5 minutes.                                                      |
+| `/home/admin/kcml-stats/stats.json`                     | droplet                     | Output of the stats generator. Bind-mounted into the mesh-web container at `/srv/api/stats.json`. |
+| `/home/admin/.rebuild-trigger/deploy-kcmesh.{log,lock}` | droplet                     | Deploy log + flock for serialization                                                              |
+
+## Stats generator
+
+`deploy/server/generate-mesh-stats.py` runs on the droplet every 5 minutes via cron. It:
+
+1. Fetches `https://map.kansascitymesh.live/api/nodes` and `/api/stats` (the local MeshMonitor instance)
+2. Computes active counts across five windows (1h / 24h / 7d / 30d / 90d), total registered nodes, top hardware breakdown
+3. Reads `DISCORD_BOT_TOKEN` from `/home/admin/.env` and queries Discord's `GET /guilds/{id}?with_counts=true` for member + presence counts
+4. Atomically writes the combined blob to `/home/admin/kcml-stats/stats.json`
+
+The site fetches this file client-side via `src/utils/liveStats.ts` to hydrate `[data-live-stat]` elements.
+
+On any non-fatal fetch failure (upstream stats or Discord), the corresponding fields become `null` and the rest of the data still ships. On primary mesh fetch failure, the script exits non-zero and leaves the previous JSON file untouched.
+
+Crontab entry (on the droplet):
+
+```cron
+*/5 * * * * /home/admin/generate-mesh-stats.py >> /home/admin/.mesh-stats.log 2>&1
+```
+
+5-minute cadence keeps the "LIVE · updated 2m ago" eyebrow honest. The fetches are cheap (MeshMonitor is loopback on the same box; Discord allows ~50 requests/sec on guild endpoints — 12 per hour is nothing). If the log grows uncomfortably, rotate it via `logrotate`; don't slow the cadence down.
+
+## Server-side `.env`
+
+`/home/admin/.env` (mode 0600) holds environment variables used by various server scripts. The stats generator reads `DISCORD_BOT_TOKEN` from this file directly because cron jobs run with minimal environment and can't rely on shell sourcing.
+
+The bot token comes from a Discord application with the **Server Members Intent** privileged gateway intent enabled and the `View Channels` permission added to the KC Mesh server. It's never in the browser, never in GitHub Actions, and never in the repo — only on the droplet.
 
 ## Secrets
 
 GitHub Actions repository secrets:
 
-| Name                | What it is                                                                                                   |
-| ------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `KCMESH_DEPLOY_KEY` | ed25519 private key. Matching public key is pinned to `deploy-kcmesh.sh` in droplet `authorized_keys`.       |
-| `DISCORD_BOT_TOKEN` | Set but not yet wired. Reserved for a follow-up that fetches the Discord guild's member count at build time. |
+| Name                | What it is                                                                                             |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
+| `KCMESH_DEPLOY_KEY` | ed25519 private key. Matching public key is pinned to `deploy-kcmesh.sh` in droplet `authorized_keys`. |
 
-## Updating the deploy script
+The Discord bot token is **not** a GitHub secret. It lives in `/home/admin/.env` on the droplet because the stats generator runs there via cron, never at build time. See the "Server-side `.env`" section above.
 
-If `deploy/server/deploy-kcmesh.sh` changes, copy the new version to the droplet:
+## Updating server-side scripts
+
+The repo holds the source of truth for both server scripts. When either changes, copy the new version up:
 
 ```bash
+# Deploy script
 scp deploy/server/deploy-kcmesh.sh admin@161.35.226.162:/home/admin/deploy-kcmesh.sh
 ssh admin@161.35.226.162 'chmod 0755 /home/admin/deploy-kcmesh.sh'
+
+# Stats generator
+scp deploy/server/generate-mesh-stats.py admin@161.35.226.162:/home/admin/generate-mesh-stats.py
+ssh admin@161.35.226.162 'chmod 0755 /home/admin/generate-mesh-stats.py'
+
+# Optional: run the stats generator once to verify it works
+ssh admin@161.35.226.162 '/home/admin/generate-mesh-stats.py'
 ```
 
-The script change should land in the same PR as any related workflow change so the two stay in sync.
+Script changes should land in the same PR as any related code change so the two stay in sync.
 
 ## Rotating the deploy key
 

--- a/deploy/server/generate-mesh-stats.py
+++ b/deploy/server/generate-mesh-stats.py
@@ -1,0 +1,283 @@
+#!/usr/bin/python3
+"""Generate a small JSON stats blob about the KC Meshtastic mesh.
+
+Fetches MeshMonitor's public API plus the KC Mesh Discord guild's member
+counts, computes total/active node counts and a hardware breakdown, and
+writes the result atomically to a path served by nginx. The
+kansascitymesh.live website fetches this file client-side to render stats.
+
+Run via cron every 5 minutes. On primary fetch failure (mesh nodes), exits
+non-zero and leaves the previous JSON file untouched so the site never sees
+a degenerate snapshot. Optional fetches (upstream stats, Discord) degrade
+gracefully — their fields become null in the output.
+
+Reads DISCORD_BOT_TOKEN from /home/admin/.env (or the environment) to call
+the Discord guild API with with_counts=true. Without the token, Discord
+fields are omitted.
+"""
+import json
+import os
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+NODES_ENDPOINT = "https://map.kansascitymesh.live/api/nodes"
+STATS_ENDPOINT = "https://map.kansascitymesh.live/api/stats"
+DISCORD_GUILD_ID = "1424474686619783191"
+DISCORD_API_BASE = "https://discord.com/api/v10"
+OUTPUT_PATH = Path("/home/admin/kcml-stats/stats.json")
+ENV_FILE = Path("/home/admin/.env")
+USER_AGENT = "kcml-stats/2"
+HTTP_TIMEOUT = 15
+SCHEMA_VERSION = 2
+
+ACTIVE_WINDOWS = {
+    "1h": 3600,
+    "24h": 86400,
+    "7d": 7 * 86400,
+    "30d": 30 * 86400,
+    "90d": 90 * 86400,
+}
+
+# Source: meshtastic/protobufs master mesh.proto, HardwareModel enum.
+# Refresh when upstream adds new IDs; unknown_hwmodel_ids in the output will flag misses.
+HW_MODELS = {
+    0: "UNSET", 1: "TLORA_V2", 2: "TLORA_V1", 3: "TLORA_V2_1_1P6", 4: "TBEAM",
+    5: "HELTEC_V2_0", 6: "TBEAM_V0P7", 7: "T_ECHO", 8: "TLORA_V1_1P3", 9: "RAK4631",
+    10: "HELTEC_V2_1", 11: "HELTEC_V1", 12: "LILYGO_TBEAM_S3_CORE", 13: "RAK11200",
+    14: "NANO_G1", 15: "TLORA_V2_1_1P8", 16: "TLORA_T3_S3", 17: "NANO_G1_EXPLORER",
+    18: "NANO_G2_ULTRA", 19: "LORA_TYPE", 20: "WIPHONE", 21: "WIO_WM1110",
+    22: "RAK2560", 23: "HELTEC_HRU_3601", 24: "HELTEC_WIRELESS_BRIDGE",
+    25: "STATION_G1", 26: "RAK11310", 27: "SENSELORA_RP2040", 28: "SENSELORA_S3",
+    29: "CANARYONE", 30: "RP2040_LORA", 31: "STATION_G2", 32: "LORA_RELAY_V1",
+    33: "T_ECHO_PLUS", 34: "PPR", 35: "GENIEBLOCKS", 36: "NRF52_UNKNOWN",
+    37: "PORTDUINO", 38: "ANDROID_SIM", 39: "DIY_V1", 40: "NRF52840_PCA10059",
+    41: "DR_DEV", 42: "M5STACK", 43: "HELTEC_V3", 44: "HELTEC_WSL_V3",
+    45: "BETAFPV_2400_TX", 46: "BETAFPV_900_NANO_TX", 47: "RPI_PICO",
+    48: "HELTEC_WIRELESS_TRACKER", 49: "HELTEC_WIRELESS_PAPER", 50: "T_DECK",
+    51: "T_WATCH_S3", 52: "PICOMPUTER_S3", 53: "HELTEC_HT62", 54: "EBYTE_ESP32_S3",
+    55: "ESP32_S3_PICO", 56: "CHATTER_2", 57: "HELTEC_WIRELESS_PAPER_V1_0",
+    58: "HELTEC_WIRELESS_TRACKER_V1_0", 59: "UNPHONE", 60: "TD_LORAC",
+    61: "CDEBYTE_EORA_S3", 62: "TWC_MESH_V4", 63: "NRF52_PROMICRO_DIY",
+    64: "RADIOMASTER_900_BANDIT_NANO", 65: "HELTEC_CAPSULE_SENSOR_V3",
+    66: "HELTEC_VISION_MASTER_T190", 67: "HELTEC_VISION_MASTER_E213",
+    68: "HELTEC_VISION_MASTER_E290", 69: "HELTEC_MESH_NODE_T114",
+    70: "SENSECAP_INDICATOR", 71: "TRACKER_T1000_E", 72: "RAK3172",
+    73: "WIO_E5", 74: "RADIOMASTER_900_BANDIT", 75: "ME25LS01_4Y10TD",
+    76: "RP2040_FEATHER_RFM95", 77: "M5STACK_COREBASIC", 78: "M5STACK_CORE2",
+    79: "RPI_PICO2", 80: "M5STACK_CORES3", 81: "SEEED_XIAO_S3",
+    82: "MS24SF1", 83: "TLORA_C6", 84: "WISMESH_TAP", 85: "ROUTASTIC",
+    86: "MESH_TAB", 87: "MESHLINK", 88: "XIAO_NRF52_KIT", 89: "THINKNODE_M1",
+    90: "THINKNODE_M2", 91: "T_ETH_ELITE", 92: "HELTEC_SENSOR_HUB",
+    93: "MUZI_BASE", 94: "HELTEC_MESH_POCKET", 95: "SEEED_SOLAR_NODE",
+    96: "NOMADSTAR_METEOR_PRO", 97: "CROWPANEL", 98: "LINK_32",
+    99: "SEEED_WIO_TRACKER_L1", 100: "SEEED_WIO_TRACKER_L1_EINK",
+    101: "MUZI_R1_NEO", 102: "T_DECK_PRO", 103: "T_LORA_PAGER",
+    104: "M5STACK_RESERVED", 105: "WISMESH_TAG", 106: "RAK3312",
+    107: "THINKNODE_M5", 108: "HELTEC_MESH_SOLAR", 109: "T_ECHO_LITE",
+    110: "HELTEC_V4", 111: "M5STACK_C6L", 112: "M5STACK_CARDPUTER_ADV",
+    113: "HELTEC_WIRELESS_TRACKER_V2", 114: "T_WATCH_ULTRA",
+    115: "THINKNODE_M3", 116: "WISMESH_TAP_V2", 117: "RAK3401",
+    118: "RAK6421", 119: "THINKNODE_M4", 120: "THINKNODE_M6",
+    121: "MESHSTICK_1262", 122: "TBEAM_1_WATT", 123: "T5_S3_EPAPER_PRO",
+    124: "TBEAM_BPF", 125: "MINI_EPAPER_S3", 126: "TDISPLAY_S3_PRO",
+    127: "HELTEC_MESH_NODE_T096", 128: "TRACKER_T1000_E_PRO",
+    129: "THINKNODE_M7", 130: "THINKNODE_M8", 131: "THINKNODE_M9",
+    132: "HELTEC_V4_R8", 133: "HELTEC_MESH_NODE_T1", 134: "STATION_G3",
+    135: "T_IMPULSE_PLUS", 136: "T_ECHO_CARD", 255: "PRIVATE_HW",
+}
+
+TOP_HARDWARE_LIMIT = 10
+
+
+def fetch_json(url: str, headers: dict | None = None) -> object:
+    req_headers = {"User-Agent": USER_AGENT}
+    if headers:
+        req_headers.update(headers)
+    req = urllib.request.Request(url, headers=req_headers)
+    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"{url} returned HTTP {resp.status}")
+        return json.loads(resp.read())
+
+
+def read_env_file(path: Path) -> dict[str, str]:
+    """Parse a simple KEY=VALUE .env file. Cron jobs run with minimal env,
+    so the script reads /home/admin/.env directly rather than relying on
+    the shell to source it."""
+    out: dict[str, str] = {}
+    if not path.exists():
+        return out
+    try:
+        for raw in path.read_text().splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            # Strip surrounding quotes if present.
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                value = value[1:-1]
+            out[key.strip()] = value
+    except OSError:
+        return {}
+    return out
+
+
+def fetch_discord_stats(token: str) -> dict:
+    """Query the Discord guild API for member counts. Returns
+    {discord_total_members, discord_online}. Either value can be None if
+    the API doesn't return it. Raises on network/auth failure so the
+    caller can decide to degrade gracefully."""
+    url = f"{DISCORD_API_BASE}/guilds/{DISCORD_GUILD_ID}?with_counts=true"
+    payload = fetch_json(url, headers={"Authorization": f"Bot {token}"})
+    if not isinstance(payload, dict):
+        raise RuntimeError("discord guild payload was not an object")
+    return {
+        "discord_total_members": payload.get("approximate_member_count"),
+        "discord_online": payload.get("approximate_presence_count"),
+    }
+
+
+def hw_entry(hw_id: int, count: int, total: int) -> dict:
+    return {
+        "hw_model": hw_id,
+        "name": HW_MODELS.get(hw_id, f"UNKNOWN_{hw_id}"),
+        "count": count,
+        "percent": round(100 * count / total, 1) if total else 0.0,
+    }
+
+
+def compute_stats(
+    nodes: list,
+    upstream_stats: dict,
+    discord_stats: dict,
+    now_epoch: int,
+) -> dict:
+    total_nodes = len(nodes)
+    nodes_with_hw = 0
+    unknown_ids: set[int] = set()
+
+    active_counts = {label: 0 for label in ACTIVE_WINDOWS}
+    hw_counts_all: Counter = Counter()
+    hw_counts_30d: Counter = Counter()
+
+    thirty_d = ACTIVE_WINDOWS["30d"]
+
+    for node in nodes:
+        user = node.get("user") or {}
+        hw = user.get("hwModel")
+        last_heard = node.get("lastHeard") or 0
+        age = max(0, now_epoch - last_heard)
+
+        for label, window in ACTIVE_WINDOWS.items():
+            if last_heard and age <= window:
+                active_counts[label] += 1
+
+        if hw is not None:
+            nodes_with_hw += 1
+            hw_counts_all[hw] += 1
+            if hw not in HW_MODELS:
+                unknown_ids.add(hw)
+            if last_heard and age <= thirty_d:
+                hw_counts_30d[hw] += 1
+
+    top_all = [hw_entry(hw, c, nodes_with_hw) for hw, c in hw_counts_all.most_common(TOP_HARDWARE_LIMIT)]
+    top_30d_total = sum(hw_counts_30d.values())
+    top_30d = [hw_entry(hw, c, top_30d_total) for hw, c in hw_counts_30d.most_common(TOP_HARDWARE_LIMIT)]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": datetime.fromtimestamp(now_epoch, tz=timezone.utc).isoformat().replace("+00:00", "Z"),
+        "generated_at_epoch": now_epoch,
+        "source": NODES_ENDPOINT,
+        "total_nodes": total_nodes,
+        "nodes_with_hwmodel": nodes_with_hw,
+        "message_count": upstream_stats.get("messageCount"),
+        "channel_count": upstream_stats.get("channelCount"),
+        "active_window_seconds": ACTIVE_WINDOWS,
+        "active_counts": active_counts,
+        "top_hardware_30d": top_30d,
+        "top_hardware_all": top_all,
+        "unknown_hwmodel_ids": sorted(unknown_ids),
+        "discord_total_members": discord_stats.get("discord_total_members"),
+        "discord_online": discord_stats.get("discord_online"),
+    }
+
+
+def write_atomic(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = json.dumps(payload, indent=2, sort_keys=False) + "\n"
+    fd, tmp_name = tempfile.mkstemp(prefix=".stats-", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(body)
+        os.chmod(tmp_name, 0o644)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def main() -> int:
+    now_epoch = int(datetime.now(tz=timezone.utc).timestamp())
+    try:
+        nodes = fetch_json(NODES_ENDPOINT)
+    except (urllib.error.URLError, TimeoutError, OSError, RuntimeError, json.JSONDecodeError) as e:
+        print(f"[{datetime.now(tz=timezone.utc).isoformat()}] fetch nodes failed: {e}", file=sys.stderr)
+        return 1
+
+    if not isinstance(nodes, list) or not nodes:
+        print(f"[{datetime.now(tz=timezone.utc).isoformat()}] refusing to write: nodes payload empty or wrong type", file=sys.stderr)
+        return 2
+
+    try:
+        upstream_stats = fetch_json(STATS_ENDPOINT)
+        if not isinstance(upstream_stats, dict):
+            upstream_stats = {}
+    except (urllib.error.URLError, TimeoutError, OSError, RuntimeError, json.JSONDecodeError) as e:
+        # Non-fatal: continue with empty upstream stats. message_count / channel_count just become null.
+        print(f"[{datetime.now(tz=timezone.utc).isoformat()}] fetch stats failed (continuing): {e}", file=sys.stderr)
+        upstream_stats = {}
+
+    # Discord guild fetch — optional. Falls back to {} if the token is
+    # missing or the API call fails. Token comes from /home/admin/.env
+    # rather than the process env so cron jobs (which run with minimal
+    # environment) pick it up reliably.
+    discord_stats: dict = {}
+    env_values = read_env_file(ENV_FILE)
+    discord_token = os.environ.get("DISCORD_BOT_TOKEN") or env_values.get("DISCORD_BOT_TOKEN")
+    if discord_token:
+        try:
+            discord_stats = fetch_discord_stats(discord_token)
+        except (urllib.error.URLError, TimeoutError, OSError, RuntimeError, json.JSONDecodeError) as e:
+            print(
+                f"[{datetime.now(tz=timezone.utc).isoformat()}] fetch discord failed (continuing): {e}",
+                file=sys.stderr,
+            )
+    else:
+        print(
+            f"[{datetime.now(tz=timezone.utc).isoformat()}] no DISCORD_BOT_TOKEN; skipping discord fetch",
+            file=sys.stderr,
+        )
+
+    payload = compute_stats(nodes, upstream_stats, discord_stats, now_epoch)
+    write_atomic(OUTPUT_PATH, payload)
+    print(
+        f"[{payload['generated_at']}] wrote {OUTPUT_PATH} "
+        f"total={payload['total_nodes']} active_24h={payload['active_counts']['24h']} "
+        f"discord_members={payload.get('discord_total_members')} "
+        f"discord_online={payload.get('discord_online')}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/components/NetworkPulse.astro
+++ b/src/components/NetworkPulse.astro
@@ -20,7 +20,7 @@ import { NETWORK_ACTIVITY, statusColor } from '../data/networkStatus';
           The mesh, right now.
         </h2>
         <p class="text-white/70 text-base leading-relaxed max-w-[480px]">
-          Not a marketing screenshot. Live counts from the KC MeshMonitor instance.
+          Counts refresh every 5 minutes from the KC MeshMonitor instance.
         </p>
       </div>
       <a


### PR DESCRIPTION
## Three coupled changes

All from the same realization: now that the stats generator includes Discord presence (which actually changes minute-to-minute), the 12-hour cron cadence was dishonest with NetworkPulse's "LIVE · updated 2m ago" eyebrow. Fixing the cadence forced revisiting where the bot token lives, which made the unused GitHub Actions secret obvious.

### 1. Track `generate-mesh-stats.py` in the repo

Previously only on the droplet. Now in `deploy/server/generate-mesh-stats.py`, alongside `deploy-kcmesh.sh`. Source-of-truth in the repo; sync-to-server steps documented in `deploy/README.md`.

### 2. Crontab: 12h → every 5 minutes

```diff
- 0 */12 * * * /home/admin/generate-mesh-stats.py >> /home/admin/.mesh-stats.log 2>&1
+ */5  * * * * /home/admin/generate-mesh-stats.py >> /home/admin/.mesh-stats.log 2>&1
```

Why every 5 min:
- **Truthful eyebrow.** "LIVE · updated 2m ago" stays accurate; at 12h it averages "7h ago."
- **Discord presence stays useful.** Member count drifts slowly (~weekly), but presence_count is the most live thing we surface. Hourly would already lose its value.
- **Cost is nothing.** MeshMonitor is loopback (same box). Discord's guild endpoint allows ~50/sec; we're doing 12/hour.
- **Failure mode improves.** A bad fetch recovers in 5 min instead of 12 hours.

Updated in this PR:
- Server crontab (live, via `crontab -l \| sed \| crontab -`)
- Script docstring
- `deploy/README.md` cron section + file table
- `NetworkPulse.astro` copy: "Counts refresh every 5 minutes from the KC MeshMonitor instance."

### 3. Delete `DISCORD_BOT_TOKEN` GitHub Actions secret

The Discord bot token lives in `/home/admin/.env` on the droplet (mode 0600), read by the cron script. It was never used at build time — GitHub Actions doesn't need it. Removed:

```bash
gh secret delete DISCORD_BOT_TOKEN
```

`deploy/README.md` now documents where the token actually lives so future-me doesn't reinstate the secret thinking it's needed.

## Files changed

| File | Change |
|---|---|
| `deploy/server/generate-mesh-stats.py` (new) | Verbatim copy of the server script, plus a docstring tweak (`every 5 minutes` not `every 12 hours`). |
| `deploy/README.md` | New "Stats generator" section, new file-table rows for the script and its output, new "Server-side `.env`" section explaining where the bot token lives, secrets table trimmed to just `KCMESH_DEPLOY_KEY`, updated sync-to-server steps for both scripts. |
| `src/components/NetworkPulse.astro` | Copy: "Counts refresh every 5 minutes…" |

## Server-side changes (live, not in the diff)

- `/home/admin/generate-mesh-stats.py` updated (matches `deploy/server/` exactly)
- `crontab -l` confirms `*/5 * * * *` cadence
- `gh secret list` confirms only `KCMESH_DEPLOY_KEY` remains

## Test plan

- [x] `npm run format:check` — clean
- [x] `npm run check` — 0 errors / 0 warnings / 49 files
- [x] `npm run build` — 13 pages in ~951ms
- [x] Crontab verified live on droplet
- [x] GitHub secret list confirms `DISCORD_BOT_TOKEN` removed
- [ ] After merge: deploy auto-fires; verify `/status` shows current Discord/mesh numbers and the "LIVE · updated" timestamp stays under ~5 minutes through the day

🤖 Generated with [Claude Code](https://claude.com/claude-code)