### PR TITLE
docs: spell out branch protection settings in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,18 @@ Not enforced by tooling, just convention.
 4. **CI runs typecheck + build** on every PR. Both have to pass before merge.
 5. **A maintainer reviews.** Small fixes typically merge same-day; larger changes might come with feedback.
 
-`main` is protected — PRs are required, and the CI check has to pass. You can't push directly.
+### Branch protection
+
+`main` is protected. Specifically:
+
+- **Direct pushes are blocked.** All changes land via PR.
+- **CI must pass.** The `Typecheck + build` check (from `.github/workflows/ci.yml`) is a required status check. Format + typecheck + build all have to be green.
+- **Force-pushes are disabled.** History on `main` can't be rewritten.
+- **Branch deletion is disabled.** Nobody can accidentally `git push --delete origin main`.
+- **Reviews are not required.** Solo-maintainer project; the maintainer can self-merge their own PRs once CI is green. If multiple maintainers come on board, this is worth revisiting.
+- **Admins aren't separately enforced.** The maintainer can bypass these rules in a genuine emergency (e.g. CI broken by an upstream change and the site needs a fix shipped). Not used for routine work.
+
+If something here ever seems wrong — for example a "Typecheck + build" required check that doesn't exist on the actual workflow — open an issue. These settings are checked in via this section, not via a `branch-protection.yml` config file, so they can drift if changed via the web UI without updating this doc.
 
 ## Issue templates
 


### PR DESCRIPTION
## What this changes

The one-line claim in `CONTRIBUTING.md` — "main is protected — PRs are required, and the CI check has to pass" — was accurate but didn't tell contributors *what* is enforced, *why*, or *what's deliberately not enforced*.

I verified the actual settings via `gh api repos/.../branches/main/protection` and expanded that line into a real list that matches reality.

## What's actually enforced on `main` right now

- Direct pushes blocked (PRs required)
- `Typecheck + build` status check from `ci.yml` must pass
- Force-pushes disabled
- Branch deletion disabled

## What's deliberately not enforced

- No required reviews (solo-maintainer; self-merge is the workflow)
- No admin enforcement (maintainer can bypass in emergency)

Both decisions are now documented in CONTRIBUTING with their reasoning, so future-me or a future co-maintainer can see what to revisit if the team grows.

## Why nothing changed in the actual settings

You explicitly chose "leave as-is" when I walked through the options. The current configuration is appropriate for the current workflow:

- Solo-maintainer means self-merge is the only practical option
- Admin bypass is the standard "I can fix this in an emergency" pattern
- Force-pushes/deletions disabled prevents accidents

If the team grows, the natural followups are: enable required reviews (1 approval), enable strict-mode (require up-to-date branches), enable admin enforcement.

## Test plan

- [x] `npm run format:check` clean
- [x] `npm run check` clean (0 errors / 0 warnings)
- [x] `npm run build` clean
- [x] Branch protection settings confirmed via `gh api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)