### PR TITLE
feat: kc-mesh-design skill replaces the design system reference folder

### DIFF
--- a/.claude/skills/kc-mesh-design/SKILL.md
+++ b/.claude/skills/kc-mesh-design/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: kc-mesh-design
+description: >
+  Use this skill for any visual, voice, or content decision in the
+  kansascitymesh.live repo or a fork of it. Triggers on: adding a
+  component or page, writing copy, picking a card / button / banner,
+  choosing a color from the palette, deciding between mono and sans,
+  reviewing or rewriting copy against the voice rules, or asking
+  "what's the right component for X." Also triggers on "design system",
+  "KC Mesh design", "InfoCard", "FeatureCard", "Cello", "Terracotta",
+  "Sage", "Inconsolata", "General Sans", "rounded SaaS", or
+  "anti-perfectionism."
+---
+
+# KC Mesh design system
+
+The design + voice rules for [kansascitymesh.live](https://kansascitymesh.live). Single-mode dark, palette-locked, two-card / four-button / two-banner vocabulary. Voice is collective first person, anti-perfectionist, sentence case.
+
+If a contributor is forking for their own city, the voice direction will need a rewrite — but the structural rules (card vocabulary, opacity scale, mono-vs-sans, anti-patterns) transfer cleanly.
+
+## Five principles that always hold
+
+1. **Polish is allowed. Polish without substance is not.** A FeatureCard around prose alone is doing too much. A FeatureCard around real evidence (live numbers, photos, the map) is doing the right job.
+2. **Collective first person, sentence case, anti-perfectionist.** "We're building," not "I'm building" or "the network provides." "Become a host," not "Become A Host." Honest about gaps and the learning curve.
+3. **Two cards. Four buttons. Two banners. No third of anything.** Restraint is the design choice. When you need a "new" surface, check whether one of the existing six covers it. Almost always, it does.
+4. **Data wears mono. Prose wears sans.** Callsigns, frequencies, hop counts, timestamps, version stamps, prices, inline code → Inconsolata (`var(--font-mono)`). Everything narrative → General Sans (the default).
+5. **Single-mode dark, single-mode warm.** Page `var(--neutral-950)`. Card `var(--neutral-900)`. No light mode. No theme switcher. The palette is the entire vocabulary.
+
+## Quick reference
+
+| When you're doing                                        | Read                                                     |
+| -------------------------------------------------------- | -------------------------------------------------------- |
+| Picking between InfoCard / FeatureCard / banner / button | `references/design-system.md` § Decision rules           |
+| Writing or reviewing copy                                | `references/voice.md`                                    |
+| Composing a new page                                     | `references/design-system.md` § Page composition recipes |
+| Wondering if something's on-brand                        | `references/design-system.md` § Anti-patterns            |
+
+## Things to internalize before generating anything
+
+- The site is **single-mode dark**. Page `var(--neutral-950)`, cards `var(--neutral-900)`, section dividers fall through to `#000`. No light mode.
+- Components are canonical: `InfoCard` + `FeatureCard` (cards), `PrimaryButton` + `DiscordButton` + `SecondaryButton` + plain text links (buttons), `TipBanner` + `MessageBanner` (banners), plus `Nav`, `Footer`, `PulsingDot`, `HardwareCard`, `NetworkPulse`, `AudienceRow`. Don't invent a third of anything.
+- Voice is **collective first person** ("we"), **sentence case**, **anti-perfectionist**. Read `references/voice.md` before writing or editing copy.
+- Iconography is **`@lucide/astro`** at 1.5–1.75 stroke. No emoji. No hand-drawn SVG.
+- Webfonts: **General Sans** (humanist sans, OFL, self-hosted from `public/fonts/`) for prose; **Inconsolata** (mono, Google Fonts) for data.
+- **Radii use Tailwind 4 defaults** (2/4/6/8/12/16 px). We had custom overrides; they're gone. Don't reinstate them.
+- Border colors via `border-white/10` (faint) or `border-white/20` (hover/strong). Never raw hex.
+
+## Tech stack at a glance
+
+- **Astro 6** (static) — `src/pages/` for routes, `src/components/` for components, `src/styles/globals.css` for tokens
+- **Tailwind CSS 4** via `@tailwindcss/postcss` — theme overrides live in `@theme { }` inside `globals.css`
+- **`@lucide/astro`** for icons
+- **`astro:assets`** for image optimization
+- **No client-side framework runtime** — two small inline `<script>` blocks for analytics delegation + live-stats hydration
+
+## When invoked without specific guidance
+
+Ask what surface is being built or edited (page? component? copy?), what audience, what content. Then act as an expert designer who outputs production-ready Astro code (`.astro` files using the canonical components) or, for throwaway prototypes, static HTML that demos a pattern. Voice + visual decisions should both match the live site unless you're explicitly designing something new.

--- a/.claude/skills/kc-mesh-design/references/design-system.md
+++ b/.claude/skills/kc-mesh-design/references/design-system.md
@@ -1,0 +1,246 @@
+# KC Mesh design system reference
+
+The decision rules. When to use which card, which button, which banner. What counts as on-brand. What counts as a violation.
+
+If `SKILL.md` is the principles, this file is the operational manual.
+
+---
+
+## Decision rules
+
+### Cards: `InfoCard` vs. `FeatureCard`
+
+| Question                                                            | Use InfoCard | Use FeatureCard |
+| ------------------------------------------------------------------- | ------------ | --------------- |
+| Is this read-only content the user is absorbing?                    | ✓            |                 |
+| Is this a focal element — a CTA, a hero stat, a showcase item?      |              | ✓               |
+| Will several of these sit in a grid together at the same hierarchy? | ✓            |                 |
+| Is there ONE of these on the page, in a moment of emphasis?         |              | ✓               |
+| Does it want to fade into the page rhythm?                          | ✓            |                 |
+| Does it want to _lift off_ the page (glass, shadow)?                |              | ✓               |
+
+**Default to `InfoCard`.** `FeatureCard` is the exception, not the rule. The audit found 25 InfoCard instances vs. 9 FeatureCards on the live site — that ratio is correct.
+
+**Anti-pattern:** four FeatureCards in a row. If you have four of anything, they're not focal, they're a list. Use InfoCards.
+
+### Buttons: which one?
+
+| Action                                                                                        | Component                                             |
+| --------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| **The single most-important action on the page.** "Become a host." "Email about a host site." | `PrimaryButton` (sage on black)                       |
+| **Go to Discord.** Any Discord invite, anywhere.                                              | `DiscordButton` (Discord blurple, three sizes)        |
+| **Supporting / external action.** "View Live Map." "Austin Mesh: Similar Networks."           | `SecondaryButton` (outline pill)                      |
+| **Nav, footer, "back to home."**                                                              | Plain text link with `text-white/70 hover:text-white` |
+
+**Rule:** one `PrimaryButton` per page, max. If you reach for a second one, you have two competing primary actions and the design is the problem.
+
+### Banners: `TipBanner` vs. `MessageBanner`
+
+| Use                                                                                                                           | Component                                 |
+| ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| **Pay attention to this specific tip / pointer.** Channel preset recommendation. Hardware suggestion. Single-paragraph aside. | `TipBanner` (sage gradient + info icon)   |
+| **What this looks like in practice.** Multi-paragraph storytelling. Deployment outcomes. Field-log moments.                   | `MessageBanner` (slate gradient, no icon) |
+
+**Rule:** if it's longer than ~3 sentences, it's a `MessageBanner`. If it's a one-shot pointer, it's a `TipBanner`.
+
+### Type: when to reach for mono
+
+| Mono                                     | Sans                 |
+| ---------------------------------------- | -------------------- |
+| Callsigns: `KCML`, `WESTKC-01`           | Headings, paragraphs |
+| Frequency labels: `915 MHz`, `Long Fast` | Section titles       |
+| Hop counts: `4 hops`                     | Body prose           |
+| Time deltas: `2m ago`, `just now`        | Button labels        |
+| SNR readings: `+6.5 dB`                  | Copy in cards        |
+| Version stamps: `v2.1.0`                 | Form labels          |
+| Inline `<code>` tokens                   |                      |
+| Big-stat numbers: `61`, `1,247`, `103`   |                      |
+| Hardware prices: `$40`, `$90`            |                      |
+
+**Rule:** if you can read it as "this is something a radio operator would type or read off a screen," it's mono. Otherwise, sans.
+
+### Foreground opacity
+
+Five values, with semantic meaning. Don't introduce a sixth.
+
+| Class           | Use                                                                      |
+| --------------- | ------------------------------------------------------------------------ |
+| `text-white`    | Headings, strong emphasis                                                |
+| `text-white/80` | `TipBanner` body **only** (the exception that brightens up to stand out) |
+| `text-white/70` | All body copy. Card bodies. Section ledes.                               |
+| `text-white/50` | Footer license, "not sure yet" hints, captions                           |
+| `text-white/30` | Version stamp; "fade into background" signal                             |
+
+**Anti-pattern:** body copy at `white/60`. The audit found 41 instances; we consolidated to `white/70`.
+
+### Backgrounds & decoration
+
+| Treatment                                     | Where                         | When to add                                    |
+| --------------------------------------------- | ----------------------------- | ---------------------------------------------- |
+| Three blurred orbs (sage / calx / terracotta) | Hero, CTAs, FinalCTA          | Top-of-page or section-of-arrival moments only |
+| Solid `bg-black`                              | Section dividers              | Default for content sections                   |
+| `bg-(--neutral-950)`                          | Page background, all subpages | Default                                        |
+| `bg-(--neutral-900)`                          | InfoCard, Footer              | Component-internal                             |
+| Grid-pattern overlay (5% opacity)             | FinalCTA                      | Reserved for closing moments                   |
+
+**Anti-pattern:** orbs on every section. They stop reading as atmosphere and start reading as decoration. One orb stack per page (the hero) is plenty.
+
+### Radii
+
+We use **Tailwind 4 defaults**. We had custom overrides (4/6/10/12) earlier; we dropped them when migrating to TW4 because the defaults are tighter and read better.
+
+| Class         | Pixels |
+| ------------- | ------ |
+| `rounded-xs`  | 2      |
+| `rounded-sm`  | 4      |
+| `rounded-md`  | 6      |
+| `rounded-lg`  | 8      |
+| `rounded-xl`  | 12     |
+| `rounded-2xl` | 16     |
+
+Component defaults:
+
+| Component                                                                                                                                          | Radius class        |
+| -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `InfoCard`, `AudienceRow`, `PrimaryButton`, `SecondaryButton`, `DiscordButton` (default), Hero icon medallion, Hardware badge, Resources medallion | `rounded-md` (6 px) |
+| `FeatureCard`, `HardwareCard`, `TipBanner`, `MessageBanner`, Host/Drone/Final CTA medallions, Hardware accent stripe                               | `rounded-lg` (8 px) |
+| `DiscordButton` (small), `Nav` logo, `AudienceRow` inner icon, status pill outer                                                                   | `rounded-sm` (4 px) |
+| Status pills, getting-started step circles, `PulsingDot`                                                                                           | `rounded-full`      |
+
+Never override radii inline.
+
+---
+
+## Page composition recipes
+
+### Homepage
+
+```
+Nav (transparent, becomes dark on scroll)
+↓
+Hero
+  · Title with gradient-text on the noun
+  · Two-up: FeatureCard (intro) + FeatureCard (map preview)
+↓
+NetworkPulse  ← the "this is actually happening" moment
+  · 3 stat tiles (Inconsolata)
+  · 6-cell activity grid (callsigns + status dots)
+↓
+HardwareSection
+  · 4-up HardwareCard grid (glass + gradient accent + photo)
+↓
+ResourcesSection
+  · 3-up FeatureCard grid (interactive)
+↓
+HostInfrastructureCTA
+  · Single large FeatureCard
+↓
+DroneFlyCTA
+  · Single large FeatureCard
+↓
+FinalCTASection
+  · Hero-style closer with medallion
+↓
+Footer
+```
+
+### Subpage / article (Get Started, Host a Node, Steal, FAQ, Field Log)
+
+```
+Nav (always dark — never transparent on subpages)
+↓
+SubpageHeader
+  · "Back to home" text link
+  · Optional kicker pill ("KC Backbone Initiative")
+  · H1 with optional gradient-accent span
+  · Lede paragraph at text-xl, white/70
+↓
+Article body — max-w-3xl (768 px)
+  · One H2 per section
+  · Body prose at text-base / white/70 / leading-relaxed
+  · InfoCards for lists of similar items
+  · TipBanner for the one pointer per section
+  · MessageBanner for the storytelling moment
+↓
+Closing CTA section
+  · padding-top: 32; border-top: 1px solid white/10
+  · One PrimaryButton + one DiscordButton, max
+↓
+Footer
+```
+
+### Dashboard / data page (`/status`)
+
+```
+Nav (dark)
+↓
+SubpageHeader — narrower top padding, no orbs, with PulsingDot eyebrow
+↓
+Stat tile grid — max-w-6xl, multiple rows by section (Active / Totals / Discord)
+↓
+Data table inside a FeatureCard (the table is the focal element)
+↓
+"Right now" MessageBanner — narrative around the data
+↓
+Footer
+```
+
+---
+
+## Anti-patterns (don't do these)
+
+Each of these is a real pattern that has been removed from the site.
+
+### Visual anti-patterns
+
+- **A third card style.** If the design seems to need one, it needs simplification, not a new component.
+- **Two `PrimaryButton`s on one page.** If you have two important actions, you have one important and one supporting.
+- **Hover on every text link.** Plain links don't need `translate-y`. Save it for buttons and cards.
+- **A new color outside the palette.** Including: pure black `#000` on a card surface (use `var(--neutral-900)`), pure white `#fff` on body text (use `text-white` only on headings and strong).
+- **Emoji.** Anywhere. Including 📡 and 🌐.
+- **Illustration.** No hand-drawn iconography. No isometric "future of comms" graphics. No people in stock photography.
+- **Light mode tokens or alternates.** The system is dark-only.
+- **Raw `#000000` borders.** Use `border-white/10` (faint) or `border-white/20` (hover/strong).
+- **Custom `--radius-*` overrides.** TW4 defaults are correct; the override block from the design-system migration was dropped on purpose.
+
+### Iconography anti-patterns
+
+- **Drawing a new SVG icon.** Use `@lucide/astro`. If lucide doesn't have it, choose a closer existing icon — don't invent.
+- **Filled icons mixed with stroked icons.** Lucide is stroke-only at 1.5–1.75 weight; the only filled glyph is the Discord brand mark.
+- **Icons sized inconsistently within a row.** Pick one size per context: 14 in nav, 16 in buttons, 20 in card headers, 24 in resource medallions, 28 in CTA medallions.
+
+---
+
+## Component cheatsheet
+
+One-line summary of every canonical component. Full source in `src/components/`.
+
+| Component         | One-line                                                                                              |
+| ----------------- | ----------------------------------------------------------------------------------------------------- |
+| `Nav`             | Fixed top nav. Transparent on home above the fold; dark on scroll/subpages. Logo + badge link to `/`. |
+| `Footer`          | Dark `var(--neutral-900)`. Nav links + copyright + license + version stamp (mono).                    |
+| `PulsingDot`      | 12-px live indicator in Meshtastic-green. Ping animation.                                             |
+| `PrimaryButton`   | Sage on black. The page's one most-important action.                                                  |
+| `SecondaryButton` | `white/5` outline pill. Supporting / external action.                                                 |
+| `DiscordButton`   | Discord blurple. Three sizes (small / default / large).                                               |
+| `InfoCard`        | Solid `var(--neutral-900)` surface. Default card. In-content lists.                                   |
+| `FeatureCard`     | Glass `white/5 backdrop-blur-xl`. Focal / showcase only.                                              |
+| `TipBanner`       | Sage gradient + info icon. "Pay attention."                                                           |
+| `MessageBanner`   | Slate gradient. Multi-paragraph narrative moments.                                                    |
+| `AudienceRow`     | Horizontal row with left-edge gradient stripe. "This is you, specifically."                           |
+| `HardwareCard`    | Glass + gradient accent + product photo. Hardware showcase only.                                      |
+| `NetworkPulse`    | Live-status block: stat tiles + activity grid. Homepage above-fold.                                   |
+
+Plus page-level section components: `HeroSection`, `HardwareSection`, `ResourcesSection`, `HostInfrastructureCTA`, `DroneFlyCTA`, `FinalCTASection`. These are composed of the canonical primitives above.
+
+---
+
+## When in doubt
+
+Ask which of these reads most true for the surface you're building:
+
+- **"This is a field log."** Lean toward sans body + mono data + `InfoCard` surfaces + restrained color.
+- **"This is a focal moment."** Lean toward `FeatureCard` + gradient accent + slightly more breathing room.
+- **"This is reference material."** Plain prose at `text-white/70` inside a `max-w-3xl` article. No cards.
+
+The vocabulary is small enough that two-or-three of these almost always cover the design problem. If none feel right, the design problem may need to be rethought — not a new component.

--- a/.claude/skills/kc-mesh-design/references/voice.md
+++ b/.claude/skills/kc-mesh-design/references/voice.md
@@ -1,0 +1,69 @@
+# KC Mesh voice
+
+Read this before writing or editing any copy on the site.
+
+The whole site reads like a **field log**, not marketing copy. The originator (Jeremy) deployed the first router and documented the process, but the public voice is collective — _we_, the community of 200+.
+
+For forkers: this voice is opinionated to KC Mesh. If you're standing up your own city's mesh site, plan to rewrite the voice direction before touching pages. See `FORK-FOR-YOUR-CITY.md` in the repo root for the conversation about that.
+
+## Pronouns
+
+- **"We"** for the KC Mesh community. Always.
+- **"You"** for the reader (welcoming, never lecturing).
+- Never **"the network" / "the team" / "KC Mesh Inc."** — third-person formal voice betrays the brand.
+
+## Tone
+
+- **Welcoming, hobbyist, anti-perfectionist.** "Deployed imperfect beats theoretical perfect."
+- **Honest about gaps.** "Most won't see the message live — but they'll see it next time they power back up."
+- **Practical specifics over hype.** Dollar amounts, hop counts, building heights, highway names.
+- **Anti-dogma posture.** Push back on "must have a 40-foot tower / horizontal antennas don't work / indoor never works" mesh folklore.
+
+## Casing
+
+- **Sentence case for everything.** Headings, buttons, nav items. No Title Case On Buttons. (e.g. "Become a host", "Steal this network", "Email about a host site".)
+- Product/place proper nouns stay capitalized: _Kansas City_, _Meshtastic_, _Heltec V4_, _Bonner Springs_, _I-35_, _Discord_.
+
+## Recurring copy patterns
+
+- **Page H1 with a gradient span on the noun.** "Kansas City has a _Mesh Network_." / "Got a rooftop, a tower, or a high spot? _We need you._" / "Steal this _network._" The colored span uses the sage→calx gradient.
+- **Parenthetical sub-headlines.** "(And we want to say, "Hi!")" / "(it's weirdly fun)". The site is unafraid of small voice asides.
+- **Live numbers as proof.** The homepage hero quotes live mesh + Discord counts via `data-live-stat` spans hydrated from `/api/stats.json`. Don't hardcode counts in copy that's meant to feel current — the data layer is set up to keep numbers honest.
+- **CTA copy is action-oriented and self-aware.** "Become a host" / "I've got a drone — let's coordinate" / "Or come say hi in Discord" / "See you out there".
+- **Anti-dogma framing** ("15 feet is fine," "indoor sometimes works," "horizontal antennas have trade-offs but work") explicitly named, not implied.
+
+## Things to **avoid** (from the voice audit)
+
+These are real patterns that have been removed from the site. The audit doc is `docs/VOICE-AUDIT-2026-05.md`; the catalog below is the operational summary.
+
+- **No wrap-up codas.** Don't end a section with "And that's the magic of community mesh networking." Just stop.
+- **No "X, not Y" rhythm tics.** "Welcoming, not corporate. Hobbyist, not professional." Over-used, smells like AI ghostwriting.
+- **No "actually / genuinely / absolutely" as superiority markers.** Cut on sight.
+- **No graduation-speech sentences.** "We're not just building a network. We're building a community."
+- **No corporate vocabulary.** "leverage," "solutions," "ecosystem," "stakeholders," "empower."
+- **No exclamation-point landing pages.** One "Hi!" in a parenthetical lede is the budget for the whole site.
+
+## Examples lifted from the live site (do this)
+
+> "Power up a Meshtastic node and say hello. Someone in the mesh will hear you."
+
+> "Start with one. Most of us end up with three or four (it's weirdly fun)."
+
+> "We're talking about a $60–$200 device the size of a paperback, plus a small antenna. Not commercial telecom gear. Weekend-project scale."
+
+> "Cascadia's first big host was a billboard owner outside Mayfield, WA. The model works."
+
+> "Resist the urge to centralize. No bylaws. No officers. No membership tiers. The minute it starts feeling like a club is the minute the most interesting people stop showing up."
+
+## Emoji
+
+**Almost never.** The site uses zero emoji in body copy. The single Heart icon (lucide) on the Steal This Network "Say hi" header is the closest thing — and it's a stroked icon, not an emoji. If you reach for 🎉 or 🚀, you're off-brand.
+
+## When in doubt
+
+Two questions to ask:
+
+1. **Would a Discord regular write this?** Or does it read like a press release? If press-release-y, rewrite.
+2. **Is there a specific number, place, or detail I could swap in for an abstract claim?** "60+ active nodes" beats "a thriving network." Specifics earn trust; abstractions don't.
+
+For deep diagnostic work on long-form copy, the `jeremy-voice` skill at `~/.claude/skills/jeremy-voice/` is the authoritative anti-pattern catalog. This file is the shorter operational version for in-site copy. They agree on principles; `jeremy-voice` has more examples and case-study mode.

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,3 @@ pnpm-debug.log*
 .idea/
 
 mt/
-
-KC Mesh Design System/

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,4 +5,3 @@ package-lock.json
 public/fonts/
 src/assets/
 LICENSE
-KC Mesh Design System/


### PR DESCRIPTION
## What this does

Converts the local-only `KC Mesh Design System/` working-reference folder into a project-local skill at `.claude/skills/kc-mesh-design/`. Any Claude session in this repo (or a fork) will auto-load it on visual / voice / design triggers.

Pairs with #31 (delete stale `.claude/agents/`) — together they replace months-old loose agent docs with a current, structured skill.

## Structure

```
.claude/skills/kc-mesh-design/
├── SKILL.md
│     Entry point — auto-loads on triggers like "InfoCard",
│     "FeatureCard", "design system", "Cello", "Inconsolata",
│     "anti-perfectionism", etc. Holds the five principles plus
│     a quick-reference index pointing at the deeper files.
└── references/
    ├── design-system.md
    │     Decision rules. When to use which card / button / banner /
    │     opacity / radius. Page composition recipes. Anti-pattern
    │     catalog. Component cheatsheet.
    └── voice.md
          Voice rules: pronouns, tone, casing, recurring copy
          patterns, things-to-avoid, on-brand examples. Points at
          the deeper jeremy-voice global skill for long-form work.
```

## What got corrected vs. the original folder

The folder predated several decisions that have since landed. The skill catches up:

- **Radii** updated to TW4 defaults (the "4/6/10/12 px" override was dropped in #24)
- **`<image-slot>`** references removed (was deferred, never built)
- **Tech stack** notes updated to Astro 6 + Tailwind 4 + `@tailwindcss/postcss`
- **Live-stats example** added — "60+ active nodes" was hardcoded; it's now a `data-live-stat` span hydrated from `/api/stats.json` (#28)
- **Component cheatsheet** trimmed to canonical primitives plus actual section components

## What got dropped from the old folder

| Dropped | Why |
|---|---|
| `MIGRATION.md` | Migration is done (#20–#23) |
| `ui_kits/` | One-shot prototyping JSX, served its purpose |
| `preview/` | Design-time HTML demo cards |
| `slides/` | Separate concern — own repo if ever needed |
| `colors_and_type.css` | Lives in `src/styles/globals.css` now |
| `fonts/` | Production copies are in `public/fonts/` |
| `assets/` | Production copies are in `src/assets/` and `public/` |

Net: skill is ~30 KB. The folder it replaces was ~1 MB+ of mostly artifacts that lived in `.gitignore`. The whole folder is removed from the working tree in this PR, and the gitignore + prettierignore entries for it are dropped.

## Why project-local instead of global

Project-local skills travel with clones. A forker cloning this repo gets `kc-mesh-design` auto-loaded the moment they `cd` in. To swap in their own city's voice and design rules, they edit `SKILL.md` + `references/voice.md` — no global skill discovery or replication needed.

This matches the spirit of `FORK-FOR-YOUR-CITY.md` — make forking as low-friction as possible.

## Test plan

- [x] `npm run format:check` clean
- [x] `npm run check` — 0 errors / 0 warnings / 49 files
- [x] `npm run build` — 13 pages
- [ ] **After merge:** open a fresh Claude session, ask "what's the right component for a single CTA on the homepage" — confirm `kc-mesh-design` loads and recommends `FeatureCard` (the actual right answer per the rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)