### PR TITLE
copy(coverage-map): 'Live near an orange dot?'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kansascitymesh.live",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kansascitymesh.live",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "dependencies": {
         "@lucide/astro": "^1.16.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kansascitymesh.live",
   "private": true,
-  "version": "2.3.2",
+  "version": "2.3.3",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/src/pages/coverage-map.astro
+++ b/src/pages/coverage-map.astro
@@ -33,7 +33,7 @@ const siteCount = coverageData.features.length;
           The green dots are nodes already on the air. The orange dots are the spots we'd most love
           a new one — high ground or a gap where a single router would noticeably widen the mesh,
           and plenty of them are just somebody's roofline or back fence, no 40-foot tower required.
-          Live near one?{' '}
+          Live near an orange dot?{' '}
           <a class="text-white underline hover:no-underline" href="/host-a-node">Host a node</a> and put
           your corner of the metro on the map.
         </p>


### PR DESCRIPTION
One-line copy tweak: 'Live near one?' -> 'Live near an orange dot?'. v2.3.3.